### PR TITLE
Close core parser perf gates and restore package type safety

### DIFF
--- a/docs/core-parser-replan.md
+++ b/docs/core-parser-replan.md
@@ -1,0 +1,156 @@
+# Core Parser Replan
+
+Updated: 2026-03-25
+
+## Fixed baselines
+
+- `main`: `/josh/programs/stax-xml`
+- `checkpoint`: `/josh/programs/stax-xml-core-parser-checkpoint`
+- `feature`: `/josh/programs/stax-xml-core-parser-refactor`
+
+Checkpoint was frozen from feature commit `97dbf5b` with a Lore commit so cursor-internal comparisons can stay stable while feature continues to move.
+
+## Operating rules
+
+- Benchmark and profiling runs use `packages/stax-xml/dist/index.js` or `packages/stax-xml/dist/index.mjs` only.
+- `main` and `checkpoint` stay fixed during the comparison window.
+- Cursor results are judged against `checkpoint`.
+- Public wrapper results are judged against `main`.
+- Stress results are recorded as signals and are not ship gates.
+
+## Benchmark suites
+
+### Cursor suite
+
+- `sync-cursor-consume`: synthetic token-dense XML
+- `sync-cursor-attr-unused`: synthetic attribute-dense XML without attribute access
+- `async-cursor-midsize-4kb`
+- `async-cursor-midsize-64kb`
+
+### Wrapper suite
+
+- `sync-parser-books`: `books.xml`
+- `sync-parser-complex`: `complex.xml`
+- `async-parser-midsize-4kb`: `midsize.xml`
+- `async-parser-midsize-64kb`: `midsize.xml`
+- `async-parser-mixed-256b`: `mixed.xml`
+
+### Stress suite
+
+- `async-parser-single-chunk`
+
+## Gate definitions
+
+### Cursor gate: checkpoint vs feature
+
+- `sync-cursor-consume`: at least 10% faster
+- `sync-cursor-attr-unused`: at least 25% faster
+- `async-cursor-midsize-4kb`: completes and stays within `1.5x`
+- `async-cursor-midsize-64kb`: completes and stays within `1.5x`
+
+### Wrapper gate: main vs feature
+
+- No representative wrapper case regresses by more than 5%
+- At least one representative wrapper case improves by at least 5%
+- Representative wrapper cases are `sync-parser-books` and `sync-parser-complex`
+- `async-parser-midsize-4kb`: feature run completes without timeout
+- `async-parser-midsize-64kb`: feature run completes without timeout
+- `async-parser-mixed-256b`: feature run completes without timeout and keeps a stable checksum
+
+### Stress suite
+
+- `async-parser-single-chunk` is signal only
+- Runaway behavior, timeout behavior, and chunk sensitivity are recorded, not used as ship gates
+
+## Workflow
+
+1. Build dist in each worktree.
+2. Verify baseline SHA pins and worktree state.
+3. Run the cursor suite for `checkpoint` and `feature`.
+4. Run the wrapper suite for `main` and `feature`.
+5. Run the stress suite for `feature` when needed.
+6. Evaluate cursor and wrapper gates from the suite JSON outputs.
+
+## Commands
+
+Build:
+
+```bash
+pnpm --dir /josh/programs/stax-xml/packages/stax-xml build
+pnpm --dir /josh/programs/stax-xml-core-parser-checkpoint/packages/stax-xml build
+pnpm --dir /josh/programs/stax-xml-core-parser-refactor/packages/stax-xml build
+```
+
+Verify baselines:
+
+```bash
+node /josh/programs/stax-xml-core-parser-refactor/scripts/verify-core-parser-baselines.mjs \
+  /josh/programs/stax-xml \
+  /josh/programs/stax-xml-core-parser-checkpoint \
+  /josh/programs/stax-xml-core-parser-refactor \
+  --expect-checkpoint 97dbf5b
+```
+
+Run benchmark suites:
+
+```bash
+node /josh/programs/stax-xml-core-parser-refactor/scripts/run-benchmark.mjs \
+  /josh/programs/stax-xml-core-parser-checkpoint checkpoint cursor checkpoint
+
+node /josh/programs/stax-xml-core-parser-refactor/scripts/run-benchmark.mjs \
+  /josh/programs/stax-xml-core-parser-refactor feature cursor checkpoint
+
+node /josh/programs/stax-xml-core-parser-refactor/scripts/run-benchmark.mjs \
+  /josh/programs/stax-xml main wrapper main
+
+node /josh/programs/stax-xml-core-parser-refactor/scripts/run-benchmark.mjs \
+  /josh/programs/stax-xml-core-parser-refactor feature wrapper main
+```
+
+Evaluate gates:
+
+```bash
+node /josh/programs/stax-xml-core-parser-refactor/scripts/evaluate-core-parser-gates.mjs \
+  cursor \
+  /tmp/stax-compare/checkpoint/benchmarks/cursor.json \
+  /tmp/stax-compare/feature/benchmarks/cursor.json
+
+node /josh/programs/stax-xml-core-parser-refactor/scripts/evaluate-core-parser-gates.mjs \
+  wrapper \
+  /tmp/stax-compare/main/benchmarks/wrapper.json \
+  /tmp/stax-compare/feature/benchmarks/wrapper.json
+```
+
+Default profiling targets:
+
+```bash
+node /josh/programs/stax-xml-core-parser-refactor/scripts/run-node-cpu-prof.mjs \
+  /josh/programs/stax-xml-core-parser-checkpoint checkpoint cursor checkpoint sync-cursor-consume \
+  /josh/programs/stax-xml-core-parser-refactor/scripts/parser-benchmark-case.mjs \
+  -- /josh/programs/stax-xml-core-parser-checkpoint cursor sync-cursor-consume checkpoint
+
+node /josh/programs/stax-xml-core-parser-refactor/scripts/run-node-cpu-prof.mjs \
+  /josh/programs/stax-xml-core-parser-refactor feature cursor checkpoint async-cursor-midsize-64kb \
+  /josh/programs/stax-xml-core-parser-refactor/scripts/parser-benchmark-case.mjs \
+  -- /josh/programs/stax-xml-core-parser-refactor cursor async-cursor-midsize-64kb checkpoint
+
+node /josh/programs/stax-xml-core-parser-refactor/scripts/run-node-cpu-prof.mjs \
+  /josh/programs/stax-xml main wrapper main sync-parser-books \
+  /josh/programs/stax-xml-core-parser-refactor/scripts/parser-benchmark-case.mjs \
+  -- /josh/programs/stax-xml wrapper sync-parser-books main
+
+node /josh/programs/stax-xml-core-parser-refactor/scripts/run-node-cpu-prof.mjs \
+  /josh/programs/stax-xml-core-parser-refactor feature wrapper main async-parser-mixed-256b \
+  /josh/programs/stax-xml-core-parser-refactor/scripts/parser-benchmark-case.mjs \
+  -- /josh/programs/stax-xml-core-parser-refactor wrapper async-parser-mixed-256b main
+```
+
+## Implementation stages
+
+- Stage 1: sync scalar state
+- Stage 2: sync no-attribute fast path
+- Stage 3: sync namespace copy-on-write
+- Stage 4: async scanner prototype
+- Stage 5: async full integration
+
+Each stage closes only after the cursor gate and wrapper gate both pass.

--- a/package.json
+++ b/package.json
@@ -20,14 +20,16 @@
     "docs:build": "pnpm --filter=stax-xml-docs build",
     "docs:preview": "pnpm --filter=stax-xml-docs preview",
     "benchmark": "pnpm --filter=benchmark dev:bench:all",
+    "bench:verify-baselines": "node ./scripts/verify-core-parser-baselines.mjs",
     "bench:run": "node ./scripts/run-benchmark.mjs",
+    "bench:evaluate": "node ./scripts/evaluate-core-parser-gates.mjs",
     "profile:run": "node ./scripts/run-node-cpu-prof.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.0.10",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
-    "tsdown": "^0.15.5",
+    "tsdown": "^0.21.4",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "docs:dev": "pnpm --filter=stax-xml-docs dev",
     "docs:build": "pnpm --filter=stax-xml-docs build",
     "docs:preview": "pnpm --filter=stax-xml-docs preview",
-    "benchmark": "pnpm --filter=benchmark dev:bench:all"
+    "benchmark": "pnpm --filter=benchmark dev:bench:all",
+    "bench:run": "node ./scripts/run-benchmark.mjs",
+    "profile:run": "node ./scripts/run-node-cpu-prof.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.0.10",

--- a/packages/stax-xml/package.json
+++ b/packages/stax-xml/package.json
@@ -10,7 +10,7 @@
   "module": "./dist/index.js",
   "devDependencies": {
     "starlight-typedoc": "^0.21.3",
-    "tsdown": "^0.15.5",
+    "tsdown": "^0.21.4",
     "typedoc": "^0.28.13",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"

--- a/packages/stax-xml/src/StaxXmlCursor.ts
+++ b/packages/stax-xml/src/StaxXmlCursor.ts
@@ -512,12 +512,13 @@ export class StaxXmlCursor {
     const nameEnd = 1 + tagName.length;
     const actualEnd = tagContent.length - (isSelfClosing ? 2 : 1);
     const parentNamespaces = this.namespaceStack[this.namespaceStack.length - 1];
-    const namespaces = hasNamespaceDeclarationInSource(
+    const hasNamespaceDeclarations = hasNamespaceDeclarationInSource(
       tagContent,
       nameEnd,
       actualEnd,
       StaxXmlCursor.isWhitespaceCode
-    )
+    );
+    const namespaces = hasNamespaceDeclarations
       ? cloneNamespaces(parentNamespaces)
       : parentNamespaces;
 
@@ -528,7 +529,8 @@ export class StaxXmlCursor {
       namespaces,
       this.attributeCollector,
       this.entityDecoder,
-      StaxXmlCursor.isWhitespaceCode
+      StaxXmlCursor.isWhitespaceCode,
+      hasNamespaceDeclarations
     );
 
     const nameInfo = resolveElementName(tagName, namespaces);

--- a/packages/stax-xml/src/StaxXmlCursor.ts
+++ b/packages/stax-xml/src/StaxXmlCursor.ts
@@ -573,7 +573,7 @@ export class StaxXmlCursor {
     }
 
     this.compactBufferIfNeeded();
-    const { done, value } = await this.reader.read();
+    const { done, value } = await this.reader!.read();
     if (done) {
       this.inputState = 'STREAM_ENDED';
       this.releaseReader();

--- a/packages/stax-xml/src/StaxXmlCursor.ts
+++ b/packages/stax-xml/src/StaxXmlCursor.ts
@@ -3,6 +3,7 @@ import { AttributeCollector } from './internal/AttributeCollector';
 import {
   cloneNamespaces,
   collectAttributesFromSource,
+  hasNamespaceDeclarationInSource,
   resolveElementName,
   type QualifiedNameInfo,
 } from './internal/XmlCursorParserUtil';
@@ -10,15 +11,6 @@ import {
 type CursorLifecycleState = 'INITIAL' | 'ACTIVE' | 'DONE' | 'FAILED';
 type AsyncInputState = 'BUFFER_READY' | 'NEED_INPUT' | 'STREAM_ENDED';
 type ParseAction = XmlEventType | 'need_input' | 'skip';
-
-interface CursorToken {
-  type: XmlEventType;
-  name?: string;
-  localName?: string;
-  prefix?: string;
-  uri?: string;
-  text?: string;
-}
 
 export interface StaxXmlCursorOptions {
   encoding?: string;
@@ -47,8 +39,16 @@ export class StaxXmlCursor {
   private readonly namespaceStack: Map<string, string>[] = [new Map<string, string>()];
   private lifecycleState: CursorLifecycleState = 'INITIAL';
   private inputState: AsyncInputState = 'NEED_INPUT';
-  private currentToken?: CursorToken;
-  private pendingEndElement?: QualifiedNameInfo;
+  private currentType?: XmlEventType;
+  private currentName?: string;
+  private currentLocalName?: string;
+  private currentPrefix?: string;
+  private currentUri?: string;
+  private currentText?: string;
+  private pendingEndName?: string;
+  private pendingEndLocalName?: string;
+  private pendingEndPrefix?: string;
+  private pendingEndUri?: string;
   private storedError?: Error;
   private busy = false;
 
@@ -128,35 +128,35 @@ export class StaxXmlCursor {
   }
 
   get eventType(): XmlEventType | undefined {
-    return this.currentToken?.type;
+    return this.currentType;
   }
 
   get name(): string | undefined {
-    return this.currentToken?.name;
+    return this.currentName;
   }
 
   get localName(): string | undefined {
-    return this.currentToken?.localName;
+    return this.currentLocalName;
   }
 
   get prefix(): string | undefined {
-    return this.currentToken?.prefix;
+    return this.currentPrefix;
   }
 
   get uri(): string | undefined {
-    return this.currentToken?.uri;
+    return this.currentUri;
   }
 
   get text(): string | undefined {
-    return this.currentToken?.text;
+    return this.currentText;
   }
 
   getText(): string {
-    if (this.currentToken?.type !== XmlEventType.CHARACTERS && this.currentToken?.type !== XmlEventType.CDATA) {
+    if (this.currentType !== XmlEventType.CHARACTERS && this.currentType !== XmlEventType.CDATA) {
       throw new Error('Current token does not expose text.');
     }
 
-    return this.currentToken.text;
+    return this.currentText!;
   }
 
   getAttributes(): Record<string, string> {
@@ -179,17 +179,19 @@ export class StaxXmlCursor {
 
     if (this.lifecycleState === 'INITIAL') {
       this.lifecycleState = 'ACTIVE';
-      this.currentToken = { type: XmlEventType.START_DOCUMENT };
+      this.setCurrentType(XmlEventType.START_DOCUMENT);
       return XmlEventType.START_DOCUMENT;
     }
 
-    if (this.pendingEndElement) {
-      const pending = this.pendingEndElement;
-      this.pendingEndElement = undefined;
-      this.currentToken = {
-        type: XmlEventType.END_ELEMENT,
-        ...pending,
-      };
+    if (this.pendingEndName !== undefined) {
+      this.setCurrent(
+        XmlEventType.END_ELEMENT,
+        this.pendingEndName,
+        this.pendingEndLocalName,
+        this.pendingEndPrefix,
+        this.pendingEndUri
+      );
+      this.clearPendingEnd();
       return XmlEventType.END_ELEMENT;
     }
 
@@ -209,7 +211,7 @@ export class StaxXmlCursor {
         }
 
         this.markDone();
-        this.currentToken = { type: XmlEventType.END_DOCUMENT };
+        this.setCurrentType(XmlEventType.END_DOCUMENT);
         return XmlEventType.END_DOCUMENT;
       }
 
@@ -339,7 +341,7 @@ export class StaxXmlCursor {
   }
 
   private parseDoctype(): ParseAction {
-    const endPos = this.findSingleByte(62, this.position);
+    const endPos = this.findDoctypeEnd(this.position + 9);
     if (endPos === -1) {
       if (this.inputState === 'STREAM_ENDED') {
         throw new Error('Unclosed DOCTYPE declaration');
@@ -349,6 +351,81 @@ export class StaxXmlCursor {
 
     this.position = endPos + 1;
     return 'skip';
+  }
+
+  private findDoctypeEnd(startPos: number): number {
+    let position = startPos;
+    let bracketDepth = 0;
+    let quoteChar = 0;
+    let inComment = false;
+
+    while (position < this.bufferLength) {
+      const currentByte = this.buffer[position];
+
+      if (inComment) {
+        if (currentByte === 45) {
+          const commentTerminator = this.matchesAsciiPattern(position, '-->');
+          if (commentTerminator === 'match') {
+            inComment = false;
+            position += 3;
+            continue;
+          }
+          if (commentTerminator === 'incomplete') {
+            return -1;
+          }
+        }
+        position++;
+        continue;
+      }
+
+      if (quoteChar !== 0) {
+        if (currentByte === quoteChar) {
+          quoteChar = 0;
+        }
+        position++;
+        continue;
+      }
+
+      if (currentByte === 34 || currentByte === 39) {
+        quoteChar = currentByte;
+        position++;
+        continue;
+      }
+
+      if (currentByte === 60) {
+        const commentStart = this.matchesAsciiPattern(position, '<!--');
+        if (commentStart === 'match') {
+          inComment = true;
+          position += 4;
+          continue;
+        }
+        if (commentStart === 'incomplete') {
+          return -1;
+        }
+      }
+
+      if (currentByte === 91) {
+        bracketDepth++;
+        position++;
+        continue;
+      }
+
+      if (currentByte === 93) {
+        if (bracketDepth > 0) {
+          bracketDepth--;
+        }
+        position++;
+        continue;
+      }
+
+      if (currentByte === 62 && bracketDepth === 0) {
+        return position;
+      }
+
+      position++;
+    }
+
+    return -1;
   }
 
   private parseCData(): ParseAction {
@@ -362,10 +439,10 @@ export class StaxXmlCursor {
 
     const safeStart = this.findSafeUtf8Boundary(this.position + 9, false);
     const safeEnd = this.findSafeUtf8Boundary(endPos, true);
-    this.currentToken = {
-      type: XmlEventType.CDATA,
-      text: this.decoder.decode(this.buffer.subarray(safeStart, safeEnd), { stream: false }),
-    };
+    this.setCurrentText(
+      XmlEventType.CDATA,
+      this.decoder.decode(this.buffer.subarray(safeStart, safeEnd), { stream: false })
+    );
     this.position = endPos + 3;
     return XmlEventType.CDATA;
   }
@@ -409,10 +486,7 @@ export class StaxXmlCursor {
     const namespaces = this.namespaceStack[this.namespaceStack.length - 1] ?? new Map<string, string>();
     this.elementStack.pop();
     this.namespaceStack.pop();
-    this.currentToken = {
-      type: XmlEventType.END_ELEMENT,
-      ...resolveElementName(tagName, namespaces),
-    };
+    this.setCurrentNameInfo(XmlEventType.END_ELEMENT, resolveElementName(tagName, namespaces));
     this.position = gtPos + 1;
     return XmlEventType.END_ELEMENT;
   }
@@ -434,10 +508,18 @@ export class StaxXmlCursor {
 
     const tagName = tagMatch[1];
     const isSelfClosing = tagMatch[3] === '/';
-    const namespaces = cloneNamespaces(this.namespaceStack[this.namespaceStack.length - 1]);
     this.currentStartTagSource = tagContent;
     const nameEnd = 1 + tagName.length;
     const actualEnd = tagContent.length - (isSelfClosing ? 2 : 1);
+    const parentNamespaces = this.namespaceStack[this.namespaceStack.length - 1];
+    const namespaces = hasNamespaceDeclarationInSource(
+      tagContent,
+      nameEnd,
+      actualEnd,
+      StaxXmlCursor.isWhitespaceCode
+    )
+      ? cloneNamespaces(parentNamespaces)
+      : parentNamespaces;
 
     collectAttributesFromSource(
       tagContent,
@@ -450,14 +532,11 @@ export class StaxXmlCursor {
     );
 
     const nameInfo = resolveElementName(tagName, namespaces);
-    this.currentToken = {
-      type: XmlEventType.START_ELEMENT,
-      ...nameInfo,
-    };
+    this.setCurrentNameInfo(XmlEventType.START_ELEMENT, nameInfo);
     this.position = gtPos + 1;
 
     if (isSelfClosing) {
-      this.pendingEndElement = nameInfo;
+      this.setPendingEnd(nameInfo);
       return XmlEventType.START_ELEMENT;
     }
 
@@ -477,15 +556,12 @@ export class StaxXmlCursor {
       return false;
     }
 
-    this.currentToken = {
-      type: XmlEventType.CHARACTERS,
-      text: decodedText,
-    };
+    this.setCurrentText(XmlEventType.CHARACTERS, decodedText);
     return true;
   }
 
   private releaseCurrentStartTagSource(): void {
-    if (this.currentToken?.type === XmlEventType.START_ELEMENT && this.currentStartTagSource.length > 0) {
+    if (this.currentType === XmlEventType.START_ELEMENT && this.currentStartTagSource.length > 0) {
       this.currentStartTagSource = '';
       this.attributeCollector.reset('');
     }
@@ -709,6 +785,25 @@ export class StaxXmlCursor {
     return true;
   }
 
+  private matchesAsciiPattern(
+    startPos: number,
+    pattern: string
+  ): 'match' | 'mismatch' | 'incomplete' {
+    if (startPos + pattern.length > this.bufferLength) {
+      return this.inputState === 'STREAM_ENDED'
+        ? 'mismatch'
+        : 'incomplete';
+    }
+
+    for (let index = 0; index < pattern.length; index++) {
+      if (this.buffer[startPos + index] !== pattern.charCodeAt(index)) {
+        return 'mismatch';
+      }
+    }
+
+    return 'match';
+  }
+
   private compileEntityDecoder(): (text: string) => string {
     if (this.options.autoDecodeEntities === false) {
       return (text) => text;
@@ -771,7 +866,7 @@ export class StaxXmlCursor {
   }
 
   private assertStartElementToken(): void {
-    if (this.currentToken?.type !== XmlEventType.START_ELEMENT) {
+    if (this.currentType !== XmlEventType.START_ELEMENT) {
       throw new Error('Current token does not expose attributes.');
     }
   }
@@ -784,11 +879,62 @@ export class StaxXmlCursor {
   private markFailed(error: Error): void {
     this.lifecycleState = 'FAILED';
     this.storedError = error;
-    this.currentToken = undefined;
+    this.clearCurrent();
     this.currentTextBuffer = '';
     this.currentStartTagSource = '';
     this.attributeCollector.reset('');
     this.releaseReader();
+  }
+
+  private clearCurrent(): void {
+    this.currentType = undefined;
+    this.currentName = undefined;
+    this.currentLocalName = undefined;
+    this.currentPrefix = undefined;
+    this.currentUri = undefined;
+    this.currentText = undefined;
+  }
+
+  private clearPendingEnd(): void {
+    this.pendingEndName = undefined;
+    this.pendingEndLocalName = undefined;
+    this.pendingEndPrefix = undefined;
+    this.pendingEndUri = undefined;
+  }
+
+  private setCurrent(
+    type: XmlEventType,
+    name?: string,
+    localName?: string,
+    prefix?: string,
+    uri?: string,
+    text?: string
+  ): void {
+    this.currentType = type;
+    this.currentName = name;
+    this.currentLocalName = localName;
+    this.currentPrefix = prefix;
+    this.currentUri = uri;
+    this.currentText = text;
+  }
+
+  private setCurrentType(type: XmlEventType): void {
+    this.setCurrent(type);
+  }
+
+  private setCurrentText(type: XmlEventType, text: string): void {
+    this.setCurrent(type, undefined, undefined, undefined, undefined, text);
+  }
+
+  private setCurrentNameInfo(type: XmlEventType, nameInfo: QualifiedNameInfo): void {
+    this.setCurrent(type, nameInfo.name, nameInfo.localName, nameInfo.prefix, nameInfo.uri);
+  }
+
+  private setPendingEnd(nameInfo: QualifiedNameInfo): void {
+    this.pendingEndName = nameInfo.name;
+    this.pendingEndLocalName = nameInfo.localName;
+    this.pendingEndPrefix = nameInfo.prefix;
+    this.pendingEndUri = nameInfo.uri;
   }
 
   private releaseReader(): void {

--- a/packages/stax-xml/src/StaxXmlCursor.ts
+++ b/packages/stax-xml/src/StaxXmlCursor.ts
@@ -1,0 +1,806 @@
+import { type AttributeInfo, XmlEventType } from './types';
+import { AttributeCollector } from './internal/AttributeCollector';
+import {
+  cloneNamespaces,
+  collectAttributesFromSource,
+  resolveElementName,
+  type QualifiedNameInfo,
+} from './internal/XmlCursorParserUtil';
+
+type CursorLifecycleState = 'INITIAL' | 'ACTIVE' | 'DONE' | 'FAILED';
+type AsyncInputState = 'BUFFER_READY' | 'NEED_INPUT' | 'STREAM_ENDED';
+type ParseAction = XmlEventType | 'need_input' | 'skip';
+
+interface CursorToken {
+  type: XmlEventType;
+  name?: string;
+  localName?: string;
+  prefix?: string;
+  uri?: string;
+  text?: string;
+}
+
+export interface StaxXmlCursorOptions {
+  encoding?: string;
+  addEntities?: { entity: string, value: string }[];
+  autoDecodeEntities?: boolean;
+  maxBufferSize?: number;
+  enableBufferCompaction?: boolean;
+  batchSize?: number;
+  batchTimeout?: number;
+}
+
+export class StaxXmlCursor {
+  private reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  private readonly decoder: TextDecoder;
+  private readonly options: StaxXmlCursorOptions;
+  private readonly entityDecoder: (text: string) => string;
+  private readonly attributeCollector: AttributeCollector;
+  private readonly bmhCache = new Map<string, Uint8Array>();
+
+  private buffer: Uint8Array;
+  private bufferLength = 0;
+  private position = 0;
+  private currentTextBuffer = '';
+  private currentStartTagSource = '';
+  private readonly elementStack: string[] = [];
+  private readonly namespaceStack: Map<string, string>[] = [new Map<string, string>()];
+  private lifecycleState: CursorLifecycleState = 'INITIAL';
+  private inputState: AsyncInputState = 'NEED_INPUT';
+  private currentToken?: CursorToken;
+  private pendingEndElement?: QualifiedNameInfo;
+  private storedError?: Error;
+  private busy = false;
+
+  private static readonly ASCII_TABLE = (() => {
+    const table = new Uint8Array(128);
+    table[9] = 1;
+    table[10] = 1;
+    table[13] = 1;
+    table[32] = 1;
+    table[60] = 2;
+    table[62] = 3;
+    table[47] = 4;
+    table[61] = 5;
+    table[33] = 6;
+    table[63] = 7;
+    table[34] = 8;
+    table[39] = 9;
+    return table;
+  })();
+
+  private static readonly ENTITY_REGEX_CACHE = new Map<string, RegExp>();
+  private static readonly DEFAULT_ENTITY_REGEX = /&(lt|gt|quot|apos|amp);/g;
+  private static readonly DEFAULT_ENTITY_MAP: Record<string, string> = {
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: '\'',
+    amp: '&',
+  };
+
+  constructor(xmlStream: ReadableStream<Uint8Array>, options: StaxXmlCursorOptions = {}) {
+    if (!(xmlStream instanceof ReadableStream)) {
+      throw new Error('xmlStream must be a web standard ReadableStream.');
+    }
+
+    this.options = {
+      encoding: 'utf-8',
+      autoDecodeEntities: true,
+      maxBufferSize: 64 * 1024,
+      enableBufferCompaction: true,
+      batchSize: 10,
+      batchTimeout: 10,
+      ...options,
+    };
+
+    this.decoder = new TextDecoder(this.options.encoding, {
+      fatal: false,
+      ignoreBOM: true,
+    });
+    this.buffer = new Uint8Array(this.options.maxBufferSize ?? 64 * 1024);
+    this.entityDecoder = this.compileEntityDecoder();
+    this.attributeCollector = new AttributeCollector(this.entityDecoder);
+    this.attributeCollector.reset('');
+    this.reader = xmlStream.getReader();
+  }
+
+  hasNext(): boolean {
+    this.assertNotBusy();
+    return this.lifecycleState !== 'DONE' && this.lifecycleState !== 'FAILED';
+  }
+
+  async next(): Promise<XmlEventType> {
+    this.assertNotBusy();
+    if (this.lifecycleState === 'FAILED') {
+      throw this.storedError;
+    }
+
+    this.busy = true;
+    try {
+      return await this.pullNextToken();
+    } catch (error) {
+      this.markFailed(error as Error);
+      throw this.storedError;
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  get eventType(): XmlEventType | undefined {
+    return this.currentToken?.type;
+  }
+
+  get name(): string | undefined {
+    return this.currentToken?.name;
+  }
+
+  get localName(): string | undefined {
+    return this.currentToken?.localName;
+  }
+
+  get prefix(): string | undefined {
+    return this.currentToken?.prefix;
+  }
+
+  get uri(): string | undefined {
+    return this.currentToken?.uri;
+  }
+
+  get text(): string | undefined {
+    return this.currentToken?.text;
+  }
+
+  getText(): string {
+    if (this.currentToken?.type !== XmlEventType.CHARACTERS && this.currentToken?.type !== XmlEventType.CDATA) {
+      throw new Error('Current token does not expose text.');
+    }
+
+    return this.currentToken.text;
+  }
+
+  getAttributes(): Record<string, string> {
+    this.assertStartElementToken();
+    return this.attributeCollector.getAttributes();
+  }
+
+  getAttributesWithPrefix(): Record<string, AttributeInfo> {
+    this.assertStartElementToken();
+    return this.attributeCollector.getAttributesWithPrefix();
+  }
+
+  getAttributeValue(rawName: string): string | undefined {
+    this.assertStartElementToken();
+    return this.attributeCollector.getAttributeValue(rawName);
+  }
+
+  private async pullNextToken(): Promise<XmlEventType> {
+    this.releaseCurrentStartTagSource();
+
+    if (this.lifecycleState === 'INITIAL') {
+      this.lifecycleState = 'ACTIVE';
+      this.currentToken = { type: XmlEventType.START_DOCUMENT };
+      return XmlEventType.START_DOCUMENT;
+    }
+
+    if (this.pendingEndElement) {
+      const pending = this.pendingEndElement;
+      this.pendingEndElement = undefined;
+      this.currentToken = {
+        type: XmlEventType.END_ELEMENT,
+        ...pending,
+      };
+      return XmlEventType.END_ELEMENT;
+    }
+
+    while (true) {
+      if (this.position >= this.bufferLength) {
+        if (this.flushCharacters()) {
+          return XmlEventType.CHARACTERS;
+        }
+
+        if (this.inputState !== 'STREAM_ENDED') {
+          await this.readMore();
+          continue;
+        }
+
+        if (this.elementStack.length > 0) {
+          throw new Error('Unexpected end of document. Not all elements were closed.');
+        }
+
+        this.markDone();
+        this.currentToken = { type: XmlEventType.END_DOCUMENT };
+        return XmlEventType.END_DOCUMENT;
+      }
+
+      const ltPos = this.findSingleByte(60, this.position);
+      if (ltPos === -1) {
+        try {
+          this.currentTextBuffer += this.readBuffer();
+        } catch (error) {
+          if (this.inputState !== 'STREAM_ENDED') {
+            await this.readMore();
+            continue;
+          }
+          throw error;
+        }
+
+        if (this.inputState !== 'STREAM_ENDED') {
+          await this.readMore();
+        }
+        continue;
+      }
+
+      if (ltPos > this.position) {
+        try {
+          this.currentTextBuffer += this.readBuffer(ltPos - this.position);
+        } catch (error) {
+          if (this.inputState !== 'STREAM_ENDED') {
+            await this.readMore();
+            continue;
+          }
+          throw error;
+        }
+      }
+
+      this.position = ltPos;
+      if (this.flushCharacters()) {
+        return XmlEventType.CHARACTERS;
+      }
+
+      if (this.position + 1 >= this.bufferLength) {
+        if (this.inputState === 'STREAM_ENDED') {
+          throw new Error('Unexpected end of document.');
+        }
+        await this.readMore();
+        continue;
+      }
+
+      const nextByte = this.buffer[this.position + 1];
+      const charType = this.getXmlCharType(nextByte);
+      let action: ParseAction;
+
+      if (charType === 4) {
+        action = this.parseEndTag();
+      } else if (charType === 6) {
+        action = this.parseBangConstruct();
+      } else if (charType === 7) {
+        action = this.parseQuestionConstruct();
+      } else {
+        action = this.parseStartTag();
+      }
+
+      if (action === 'need_input') {
+        await this.readMore();
+        continue;
+      }
+      if (action === 'skip') {
+        continue;
+      }
+      return action;
+    }
+  }
+
+  private parseBangConstruct(): ParseAction {
+    if (this.matchesPattern('<!--')) {
+      return this.parseComment();
+    }
+    if (this.matchesPattern('<![CDATA[')) {
+      return this.parseCData();
+    }
+    if (this.matchesPattern('<!DOCTYPE')) {
+      return this.parseDoctype();
+    }
+
+    if (this.inputState === 'STREAM_ENDED') {
+      throw new Error(`Malformed XML near position ${this.position}`);
+    }
+    return 'need_input';
+  }
+
+  private parseQuestionConstruct(): ParseAction {
+    if (this.matchesPattern('<?xml')) {
+      return this.parseXmlDeclaration();
+    }
+    if (this.matchesPattern('<?')) {
+      return this.parseProcessingInstruction();
+    }
+
+    if (this.inputState === 'STREAM_ENDED') {
+      throw new Error(`Malformed XML near position ${this.position}`);
+    }
+    return 'need_input';
+  }
+
+  private parseXmlDeclaration(): ParseAction {
+    const endPos = this.findPatternBMH('?>');
+    if (endPos === -1) {
+      if (this.inputState === 'STREAM_ENDED') {
+        throw new Error('Unclosed processing instruction');
+      }
+      return 'need_input';
+    }
+
+    this.position = endPos + 2;
+    return 'skip';
+  }
+
+  private parseComment(): ParseAction {
+    const endPos = this.findPatternBMH('-->');
+    if (endPos === -1) {
+      if (this.inputState === 'STREAM_ENDED') {
+        throw new Error('Unclosed comment');
+      }
+      return 'need_input';
+    }
+
+    this.position = endPos + 3;
+    return 'skip';
+  }
+
+  private parseDoctype(): ParseAction {
+    const endPos = this.findSingleByte(62, this.position);
+    if (endPos === -1) {
+      if (this.inputState === 'STREAM_ENDED') {
+        throw new Error('Unclosed DOCTYPE declaration');
+      }
+      return 'need_input';
+    }
+
+    this.position = endPos + 1;
+    return 'skip';
+  }
+
+  private parseCData(): ParseAction {
+    const endPos = this.findPatternBMH(']]>');
+    if (endPos === -1) {
+      if (this.inputState === 'STREAM_ENDED') {
+        throw new Error('Unclosed CDATA section');
+      }
+      return 'need_input';
+    }
+
+    const safeStart = this.findSafeUtf8Boundary(this.position + 9, false);
+    const safeEnd = this.findSafeUtf8Boundary(endPos, true);
+    this.currentToken = {
+      type: XmlEventType.CDATA,
+      text: this.decoder.decode(this.buffer.subarray(safeStart, safeEnd), { stream: false }),
+    };
+    this.position = endPos + 3;
+    return XmlEventType.CDATA;
+  }
+
+  private parseProcessingInstruction(): ParseAction {
+    const endPos = this.findPatternBMH('?>');
+    if (endPos === -1) {
+      if (this.inputState === 'STREAM_ENDED') {
+        throw new Error('Unclosed processing instruction');
+      }
+      return 'need_input';
+    }
+
+    this.position = endPos + 2;
+    return 'skip';
+  }
+
+  private parseEndTag(): ParseAction {
+    const gtPos = this.findSingleByte(62, this.position);
+    if (gtPos === -1) {
+      if (this.inputState === 'STREAM_ENDED') {
+        throw new Error('Unclosed end tag');
+      }
+      return 'need_input';
+    }
+
+    const tagContent = this.safeDecodeRange(this.position, gtPos + 1);
+    const closeTagMatch = tagContent.match(/^<\/([a-zA-Z0-9_:.\-\u0080-\uFFFF]+)\s*>$/);
+    if (!closeTagMatch) {
+      throw new Error('Malformed closing tag');
+    }
+
+    const tagName = closeTagMatch[1];
+    if (this.elementStack.length === 0) {
+      throw new Error(`Mismatched closing tag: </${tagName}>. Expected </nothing>`);
+    }
+    if (this.elementStack[this.elementStack.length - 1] !== tagName) {
+      throw new Error(`Mismatched closing tag: </${tagName}>. Expected </${this.elementStack[this.elementStack.length - 1]}>`);
+    }
+
+    const namespaces = this.namespaceStack[this.namespaceStack.length - 1] ?? new Map<string, string>();
+    this.elementStack.pop();
+    this.namespaceStack.pop();
+    this.currentToken = {
+      type: XmlEventType.END_ELEMENT,
+      ...resolveElementName(tagName, namespaces),
+    };
+    this.position = gtPos + 1;
+    return XmlEventType.END_ELEMENT;
+  }
+
+  private parseStartTag(): ParseAction {
+    const gtPos = this.findSingleByte(62, this.position);
+    if (gtPos === -1) {
+      if (this.inputState === 'STREAM_ENDED') {
+        throw new Error('Unclosed start tag');
+      }
+      return 'need_input';
+    }
+
+    const tagContent = this.safeDecodeRange(this.position, gtPos + 1);
+    const tagMatch = tagContent.match(/^<([a-zA-Z0-9_:.\-\u0080-\uFFFF]+)(\s+[^>]*?)?\s*(\/?)>$/);
+    if (!tagMatch) {
+      throw new Error('Malformed start tag');
+    }
+
+    const tagName = tagMatch[1];
+    const isSelfClosing = tagMatch[3] === '/';
+    const namespaces = cloneNamespaces(this.namespaceStack[this.namespaceStack.length - 1]);
+    this.currentStartTagSource = tagContent;
+    const nameEnd = 1 + tagName.length;
+    const actualEnd = tagContent.length - (isSelfClosing ? 2 : 1);
+
+    collectAttributesFromSource(
+      tagContent,
+      nameEnd,
+      actualEnd,
+      namespaces,
+      this.attributeCollector,
+      this.entityDecoder,
+      StaxXmlCursor.isWhitespaceCode
+    );
+
+    const nameInfo = resolveElementName(tagName, namespaces);
+    this.currentToken = {
+      type: XmlEventType.START_ELEMENT,
+      ...nameInfo,
+    };
+    this.position = gtPos + 1;
+
+    if (isSelfClosing) {
+      this.pendingEndElement = nameInfo;
+      return XmlEventType.START_ELEMENT;
+    }
+
+    this.elementStack.push(tagName);
+    this.namespaceStack.push(namespaces);
+    return XmlEventType.START_ELEMENT;
+  }
+
+  private flushCharacters(): boolean {
+    if (this.currentTextBuffer.length === 0) {
+      return false;
+    }
+
+    const decodedText = this.entityDecoder(this.currentTextBuffer);
+    this.currentTextBuffer = '';
+    if (decodedText.trim().length === 0) {
+      return false;
+    }
+
+    this.currentToken = {
+      type: XmlEventType.CHARACTERS,
+      text: decodedText,
+    };
+    return true;
+  }
+
+  private releaseCurrentStartTagSource(): void {
+    if (this.currentToken?.type === XmlEventType.START_ELEMENT && this.currentStartTagSource.length > 0) {
+      this.currentStartTagSource = '';
+      this.attributeCollector.reset('');
+    }
+  }
+
+  private async readMore(): Promise<void> {
+    if (this.inputState === 'STREAM_ENDED') {
+      return;
+    }
+
+    this.compactBufferIfNeeded();
+    const { done, value } = await this.reader.read();
+    if (done) {
+      this.inputState = 'STREAM_ENDED';
+      this.releaseReader();
+      return;
+    }
+
+    this.appendToBuffer(value);
+    this.inputState = 'BUFFER_READY';
+  }
+
+  private appendToBuffer(newData: Uint8Array): void {
+    const requiredSize = this.bufferLength + newData.length;
+    if (requiredSize > this.buffer.length) {
+      const newSize = Math.max(this.buffer.length * 2, requiredSize);
+      const newBuffer = new Uint8Array(newSize);
+      newBuffer.set(this.buffer.subarray(0, this.bufferLength));
+      this.buffer = newBuffer;
+    }
+
+    this.buffer.set(newData, this.bufferLength);
+    this.bufferLength += newData.length;
+  }
+
+  private compactBufferIfNeeded(): void {
+    if (!this.options.enableBufferCompaction) {
+      return;
+    }
+
+    const maxSize = this.options.maxBufferSize ?? 64 * 1024;
+    const shouldCompact =
+      (this.position > 8192 && this.bufferLength > 16384) ||
+      (this.position > maxSize / 2) ||
+      (this.bufferLength > maxSize && this.position > maxSize / 4);
+
+    if (!shouldCompact || this.position === 0 || this.position >= this.bufferLength) {
+      return;
+    }
+
+    const safePos = this.findSafeUtf8Boundary(this.position, true);
+    const remainingLength = this.bufferLength - safePos;
+    if (remainingLength < safePos) {
+      const newBuffer = new Uint8Array(this.buffer.length);
+      newBuffer.set(this.buffer.subarray(safePos, this.bufferLength));
+      this.buffer = newBuffer;
+    } else {
+      this.buffer.copyWithin(0, safePos, this.bufferLength);
+    }
+
+    this.bufferLength = remainingLength;
+    this.position -= safePos;
+    if (this.bmhCache.size > 20) {
+      this.bmhCache.clear();
+    }
+  }
+
+  private readBuffer(length?: number): string {
+    const originalPos = this.position;
+    let endPos = length ? Math.min(this.position + length, this.bufferLength) : this.bufferLength;
+    if (length && endPos < this.bufferLength) {
+      endPos = this.findSafeUtf8Boundary(endPos, true);
+    }
+
+    const slice = this.buffer.subarray(this.position, endPos);
+    try {
+      const result = this.decoder.decode(slice, { stream: this.inputState !== 'STREAM_ENDED' });
+      this.position = endPos;
+      return result;
+    } catch (error) {
+      if (this.inputState !== 'STREAM_ENDED' && endPos === this.bufferLength) {
+        for (let i = 1; i <= 4 && endPos - i > this.position; i++) {
+          const testEnd = this.findSafeUtf8Boundary(endPos - i, true);
+          if (testEnd <= this.position) {
+            continue;
+          }
+          try {
+            const safeSlice = this.buffer.subarray(this.position, testEnd);
+            const result = this.decoder.decode(safeSlice, { stream: true });
+            this.position = testEnd;
+            return result;
+          } catch {
+            continue;
+          }
+        }
+      }
+      this.position = originalPos;
+      throw error;
+    }
+  }
+
+  private safeDecodeRange(start: number, end: number): string {
+    const safeStart = this.findSafeUtf8Boundary(start, false);
+    const safeEnd = this.findSafeUtf8Boundary(end, true);
+    if (safeStart >= safeEnd) {
+      return '';
+    }
+
+    return this.decoder.decode(this.buffer.subarray(safeStart, safeEnd), { stream: false });
+  }
+
+  private findSafeUtf8Boundary(pos: number, searchBackward: boolean): number {
+    if (pos <= 0 || pos >= this.bufferLength) {
+      return pos;
+    }
+
+    if (searchBackward) {
+      let safePos = pos;
+      let backtrack = 0;
+      while (safePos > 0 && backtrack < 4) {
+        if (this.isUtf8CharStart(this.buffer[safePos])) {
+          const sequenceLength = this.getUtf8SequenceLength(this.buffer[safePos]);
+          if (safePos + sequenceLength > pos) {
+            return safePos;
+          }
+          return pos;
+        }
+        safePos--;
+        backtrack++;
+      }
+      return pos;
+    }
+
+    while (pos < this.bufferLength && !this.isUtf8CharStart(this.buffer[pos])) {
+      pos++;
+    }
+    return pos;
+  }
+
+  private isUtf8CharStart(byte: number): boolean {
+    return (byte & 0x80) === 0 || (byte & 0xC0) === 0xC0;
+  }
+
+  private getUtf8SequenceLength(byte: number): number {
+    if ((byte & 0x80) === 0) return 1;
+    if ((byte & 0xE0) === 0xC0) return 2;
+    if ((byte & 0xF0) === 0xE0) return 3;
+    if ((byte & 0xF8) === 0xF0) return 4;
+    return 1;
+  }
+
+  private buildBMHTable(pattern: Uint8Array): Uint8Array {
+    const table = new Uint8Array(256);
+    table.fill(pattern.length);
+    for (let i = 0; i < pattern.length - 1; i++) {
+      table[pattern[i]] = pattern.length - 1 - i;
+    }
+    return table;
+  }
+
+  private findPatternBMH(pattern: string, startPos = this.position): number {
+    const patternBytes = new TextEncoder().encode(pattern);
+    if (patternBytes.length === 0) {
+      return -1;
+    }
+    if (patternBytes.length === 1) {
+      return this.findSingleByte(patternBytes[0], startPos);
+    }
+
+    let skipTable = this.bmhCache.get(pattern);
+    if (!skipTable) {
+      skipTable = this.buildBMHTable(patternBytes);
+      if (this.bmhCache.size > 20) {
+        this.bmhCache.clear();
+      }
+      this.bmhCache.set(pattern, skipTable);
+    }
+
+    const bufferEnd = this.bufferLength - patternBytes.length;
+    let pos = startPos;
+    while (pos <= bufferEnd) {
+      let i = patternBytes.length - 1;
+      while (i >= 0 && this.buffer[pos + i] === patternBytes[i]) {
+        i--;
+      }
+      if (i < 0) {
+        return pos;
+      }
+      pos += skipTable[this.buffer[pos + patternBytes.length - 1]];
+    }
+
+    return -1;
+  }
+
+  private findSingleByte(byte: number, startPos = this.position): number {
+    const end4 = this.bufferLength - 3;
+    let i = startPos;
+    for (; i < end4; i += 4) {
+      if (this.buffer[i] === byte) return i;
+      if (this.buffer[i + 1] === byte) return i + 1;
+      if (this.buffer[i + 2] === byte) return i + 2;
+      if (this.buffer[i + 3] === byte) return i + 3;
+    }
+    for (; i < this.bufferLength; i++) {
+      if (this.buffer[i] === byte) return i;
+    }
+    return -1;
+  }
+
+  private matchesPattern(pattern: string): boolean {
+    const patternBytes = new TextEncoder().encode(pattern);
+    if (this.position + patternBytes.length > this.bufferLength) {
+      return false;
+    }
+
+    for (let i = 0; i < patternBytes.length; i++) {
+      if (this.buffer[this.position + i] !== patternBytes[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private compileEntityDecoder(): (text: string) => string {
+    if (this.options.autoDecodeEntities === false) {
+      return (text) => text;
+    }
+
+    if (this.options.addEntities && this.options.addEntities.length > 0) {
+      const entityMap: Record<string, string> = { ...StaxXmlCursor.DEFAULT_ENTITY_MAP };
+      const patterns: string[] = ['lt', 'gt', 'quot', 'apos'];
+      for (const { entity, value } of this.options.addEntities) {
+        if (entity && value) {
+          const key = entity.startsWith('&') && entity.endsWith(';')
+            ? entity.slice(1, -1)
+            : entity;
+          entityMap[key] = value;
+          patterns.push(key);
+        }
+      }
+      patterns.push('amp');
+
+      const cacheKey = patterns.join(',');
+      let regex = StaxXmlCursor.ENTITY_REGEX_CACHE.get(cacheKey);
+      if (!regex) {
+        const pattern = patterns
+          .sort((left, right) => right.length - left.length)
+          .map((entity) => entity.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+          .join('|');
+        regex = new RegExp(`&(${pattern});`, 'g');
+        StaxXmlCursor.ENTITY_REGEX_CACHE.set(cacheKey, regex);
+      }
+
+      return (text: string) => {
+        if (!text || text.indexOf('&') === -1) {
+          return text;
+        }
+        regex.lastIndex = 0;
+        return text.replace(regex, (_, entity) => entityMap[entity] || _);
+      };
+    }
+
+    return (text: string) => {
+      if (!text || text.indexOf('&') === -1) {
+        return text;
+      }
+      StaxXmlCursor.DEFAULT_ENTITY_REGEX.lastIndex = 0;
+      return text.replace(
+        StaxXmlCursor.DEFAULT_ENTITY_REGEX,
+        (_, entity) => StaxXmlCursor.DEFAULT_ENTITY_MAP[entity] || _
+      );
+    };
+  }
+
+  private getXmlCharType(byte: number): number {
+    return byte < 128 ? StaxXmlCursor.ASCII_TABLE[byte] : 0;
+  }
+
+  private assertNotBusy(): void {
+    if (this.busy) {
+      throw new Error('Concurrent cursor access is not allowed.');
+    }
+  }
+
+  private assertStartElementToken(): void {
+    if (this.currentToken?.type !== XmlEventType.START_ELEMENT) {
+      throw new Error('Current token does not expose attributes.');
+    }
+  }
+
+  private markDone(): void {
+    this.lifecycleState = 'DONE';
+    this.releaseReader();
+  }
+
+  private markFailed(error: Error): void {
+    this.lifecycleState = 'FAILED';
+    this.storedError = error;
+    this.currentToken = undefined;
+    this.currentTextBuffer = '';
+    this.currentStartTagSource = '';
+    this.attributeCollector.reset('');
+    this.releaseReader();
+  }
+
+  private releaseReader(): void {
+    if (this.reader) {
+      this.reader.releaseLock();
+      this.reader = null;
+    }
+  }
+
+  private static isWhitespaceCode(code: number): boolean {
+    return code < 128 ? StaxXmlCursor.ASCII_TABLE[code] === 1 : code <= 32;
+  }
+}
+
+export default StaxXmlCursor;

--- a/packages/stax-xml/src/StaxXmlCursorSync.ts
+++ b/packages/stax-xml/src/StaxXmlCursorSync.ts
@@ -4,8 +4,6 @@ import {
   cloneNamespaces,
   collectAttributesFromSource,
   hasNamespaceDeclarationInSource,
-  resolveElementName,
-  type QualifiedNameInfo,
 } from './internal/XmlCursorParserUtil';
 
 export interface StaxXmlCursorSyncOptions {
@@ -90,7 +88,12 @@ export class StaxXmlCursorSync {
     try {
       if (this.lifecycleState === 'INITIAL') {
         this.lifecycleState = 'ACTIVE';
-        this.setCurrentType(XmlEventType.START_DOCUMENT);
+        this.currentType = XmlEventType.START_DOCUMENT;
+        this.currentName = undefined;
+        this.currentLocalName = undefined;
+        this.currentPrefix = undefined;
+        this.currentUri = undefined;
+        this.currentText = undefined;
         return XmlEventType.START_DOCUMENT;
       }
 
@@ -113,7 +116,12 @@ export class StaxXmlCursorSync {
           }
 
           this.lifecycleState = 'DONE';
-          this.setCurrentType(XmlEventType.END_DOCUMENT);
+          this.currentType = XmlEventType.END_DOCUMENT;
+          this.currentName = undefined;
+          this.currentLocalName = undefined;
+          this.currentPrefix = undefined;
+          this.currentUri = undefined;
+          this.currentText = undefined;
           return XmlEventType.END_DOCUMENT;
         }
 
@@ -125,7 +133,12 @@ export class StaxXmlCursorSync {
             continue;
           }
 
-          this.setCurrentText(XmlEventType.CHARACTERS, this.entityDecoder(text));
+          this.currentType = XmlEventType.CHARACTERS;
+          this.currentName = undefined;
+          this.currentLocalName = undefined;
+          this.currentPrefix = undefined;
+          this.currentUri = undefined;
+          this.currentText = this.entityDecoder(text);
           return XmlEventType.CHARACTERS;
         }
 
@@ -136,7 +149,12 @@ export class StaxXmlCursorSync {
             continue;
           }
 
-          this.setCurrentText(XmlEventType.CHARACTERS, this.entityDecoder(text));
+          this.currentType = XmlEventType.CHARACTERS;
+          this.currentName = undefined;
+          this.currentLocalName = undefined;
+          this.currentPrefix = undefined;
+          this.currentUri = undefined;
+          this.currentText = this.entityDecoder(text);
           return XmlEventType.CHARACTERS;
         }
 
@@ -239,14 +257,13 @@ export class StaxXmlCursorSync {
 
     const tagName = this.xml.slice(tagStart, nameEnd);
     const parentNamespaces = this.namespaceStack[this.namespaceStack.length - 1];
-    const namespaces = hasNamespaceDeclarationInSource(
+    const hasNamespaceDeclarations = hasNamespaceDeclarationInSource(
       this.xml,
       nameEnd,
       actualEnd,
       StaxXmlCursorSync.isWhitespace
-    )
-      ? cloneNamespaces(parentNamespaces)
-      : parentNamespaces;
+    );
+    const namespaces = hasNamespaceDeclarations ? cloneNamespaces(parentNamespaces) : parentNamespaces;
     collectAttributesFromSource(
       this.xml,
       nameEnd,
@@ -254,16 +271,28 @@ export class StaxXmlCursorSync {
       namespaces,
       this.attributeCollector,
       this.entityDecoder,
-      StaxXmlCursorSync.isWhitespace
+      StaxXmlCursorSync.isWhitespace,
+      hasNamespaceDeclarations
     );
 
-    const nameInfo = resolveElementName(tagName, namespaces);
-    this.setCurrentNameInfo(XmlEventType.START_ELEMENT, nameInfo);
+    const colonIndex = tagName.indexOf(':');
+    const prefix = colonIndex === -1 ? undefined : tagName.slice(0, colonIndex);
+    const localName = colonIndex === -1 ? tagName : tagName.slice(colonIndex + 1);
+    const uri = prefix === undefined ? namespaces.get('') : namespaces.get(prefix);
+    this.currentType = XmlEventType.START_ELEMENT;
+    this.currentName = tagName;
+    this.currentLocalName = localName;
+    this.currentPrefix = prefix;
+    this.currentUri = uri;
+    this.currentText = undefined;
 
     this.pos = tagEnd + 1;
 
     if (isSelfClosing) {
-      this.setPendingEnd(nameInfo);
+      this.pendingEndName = tagName;
+      this.pendingEndLocalName = localName;
+      this.pendingEndPrefix = prefix;
+      this.pendingEndUri = uri;
       return XmlEventType.START_ELEMENT;
     }
 
@@ -290,7 +319,14 @@ export class StaxXmlCursorSync {
 
     this.elementStack.pop();
     const namespaces = this.namespaceStack.pop() ?? new Map<string, string>();
-    this.setCurrentNameInfo(XmlEventType.END_ELEMENT, resolveElementName(fullTagName, namespaces));
+    const colonIndex = fullTagName.indexOf(':');
+    const prefix = colonIndex === -1 ? undefined : fullTagName.slice(0, colonIndex);
+    this.currentType = XmlEventType.END_ELEMENT;
+    this.currentName = fullTagName;
+    this.currentLocalName = colonIndex === -1 ? fullTagName : fullTagName.slice(colonIndex + 1);
+    this.currentPrefix = prefix;
+    this.currentUri = prefix === undefined ? namespaces.get('') : namespaces.get(prefix);
+    this.currentText = undefined;
     this.pos = tagClose + 1;
     return XmlEventType.END_ELEMENT;
   }
@@ -302,7 +338,12 @@ export class StaxXmlCursorSync {
         throw new Error('Unclosed CDATA section');
       }
 
-      this.setCurrentText(XmlEventType.CDATA, this.xml.slice(this.pos + 9, cdataEnd));
+      this.currentType = XmlEventType.CDATA;
+      this.currentName = undefined;
+      this.currentLocalName = undefined;
+      this.currentPrefix = undefined;
+      this.currentUri = undefined;
+      this.currentText = this.xml.slice(this.pos + 9, cdataEnd);
       this.pos = cdataEnd + 3;
       return XmlEventType.CDATA;
     }
@@ -434,25 +475,6 @@ export class StaxXmlCursorSync {
     this.currentPrefix = prefix;
     this.currentUri = uri;
     this.currentText = text;
-  }
-
-  private setCurrentType(type: XmlEventType): void {
-    this.setCurrent(type);
-  }
-
-  private setCurrentText(type: XmlEventType, text: string): void {
-    this.setCurrent(type, undefined, undefined, undefined, undefined, text);
-  }
-
-  private setCurrentNameInfo(type: XmlEventType, nameInfo: QualifiedNameInfo): void {
-    this.setCurrent(type, nameInfo.name, nameInfo.localName, nameInfo.prefix, nameInfo.uri);
-  }
-
-  private setPendingEnd(nameInfo: QualifiedNameInfo): void {
-    this.pendingEndName = nameInfo.name;
-    this.pendingEndLocalName = nameInfo.localName;
-    this.pendingEndPrefix = nameInfo.prefix;
-    this.pendingEndUri = nameInfo.uri;
   }
 
   private findChar(targetCode: number, start = this.pos): number {

--- a/packages/stax-xml/src/StaxXmlCursorSync.ts
+++ b/packages/stax-xml/src/StaxXmlCursorSync.ts
@@ -1,0 +1,517 @@
+import { type AttributeInfo, XmlEventType } from './types';
+import { AttributeCollector } from './internal/AttributeCollector';
+import {
+  cloneNamespaces,
+  collectAttributesFromSource,
+  resolveElementName,
+  type QualifiedNameInfo,
+} from './internal/XmlCursorParserUtil';
+
+export interface StaxXmlCursorSyncOptions {
+  autoDecodeEntities?: boolean;
+  addEntities?: { entity: string, value: string }[];
+}
+
+type CursorLifecycleState = 'INITIAL' | 'ACTIVE' | 'DONE' | 'FAILED';
+
+interface CursorToken {
+  type: XmlEventType;
+  name?: string;
+  localName?: string;
+  prefix?: string;
+  uri?: string;
+  text?: string;
+}
+
+export class StaxXmlCursorSync {
+  private readonly xml: string;
+  private readonly xmlLength: number;
+  private pos = 0;
+  private readonly elementStack: string[] = [];
+  private readonly namespaceStack: Map<string, string>[] = [new Map<string, string>()];
+  private lifecycleState: CursorLifecycleState = 'INITIAL';
+  private currentToken?: CursorToken;
+  private pendingEndElement?: QualifiedNameInfo;
+  private storedError?: Error;
+
+  private static readonly ASCII_TABLE = (() => {
+    const table = new Uint8Array(128);
+    table[9] = 1;
+    table[10] = 1;
+    table[13] = 1;
+    table[32] = 1;
+    table[34] = 8;
+    table[39] = 9;
+    return table;
+  })();
+
+  private static readonly UNICODE_WHITESPACE = new Set([
+    0x00A0,
+    0x1680,
+    0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007, 0x2008, 0x2009, 0x200A,
+    0x2028,
+    0x2029,
+    0x202F,
+    0x205F,
+    0x3000,
+    0xFEFF
+  ]);
+
+  private static readonly ENTITY_REGEX_CACHE = new Map<string, RegExp>();
+  private static readonly DEFAULT_ENTITY_REGEX = /&(lt|gt|quot|apos|amp);/g;
+  private static readonly DEFAULT_ENTITY_MAP: Record<string, string> = {
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: '\'',
+    amp: '&',
+  };
+
+  private readonly entityDecoder: (text: string) => string;
+  private readonly attributeCollector: AttributeCollector;
+
+  constructor(xml: string, options: StaxXmlCursorSyncOptions = {}) {
+    this.xml = xml;
+    this.xmlLength = xml.length;
+    this.entityDecoder = this.compileEntityDecoder(options);
+    this.attributeCollector = new AttributeCollector(this.entityDecoder);
+    this.attributeCollector.reset(this.xml);
+  }
+
+  hasNext(): boolean {
+    return this.lifecycleState !== 'DONE' && this.lifecycleState !== 'FAILED';
+  }
+
+  next(): XmlEventType {
+    if (this.lifecycleState === 'FAILED') {
+      throw this.storedError;
+    }
+
+    try {
+      if (this.lifecycleState === 'INITIAL') {
+        this.lifecycleState = 'ACTIVE';
+        this.currentToken = { type: XmlEventType.START_DOCUMENT };
+        return XmlEventType.START_DOCUMENT;
+      }
+
+      if (this.pendingEndElement) {
+        const pending = this.pendingEndElement;
+        this.pendingEndElement = undefined;
+        this.currentToken = {
+          type: XmlEventType.END_ELEMENT,
+          ...pending,
+        };
+        return XmlEventType.END_ELEMENT;
+      }
+
+      while (true) {
+        if (this.pos >= this.xmlLength) {
+          if (this.elementStack.length > 0) {
+            return this.fail(new Error('Unexpected end of document. Not all elements were closed.'));
+          }
+
+          this.lifecycleState = 'DONE';
+          this.currentToken = { type: XmlEventType.END_DOCUMENT };
+          return XmlEventType.END_DOCUMENT;
+        }
+
+        const ltPos = this.findChar(60, this.pos);
+        if (ltPos === -1) {
+          const text = this.trimmedSlice(this.pos, this.xmlLength);
+          this.pos = this.xmlLength;
+          if (!text) {
+            continue;
+          }
+
+          this.currentToken = {
+            type: XmlEventType.CHARACTERS,
+            text: this.entityDecoder(text),
+          };
+          return XmlEventType.CHARACTERS;
+        }
+
+        if (ltPos > this.pos) {
+          const text = this.trimmedSlice(this.pos, ltPos);
+          this.pos = ltPos;
+          if (!text) {
+            continue;
+          }
+
+          this.currentToken = {
+            type: XmlEventType.CHARACTERS,
+            text: this.entityDecoder(text),
+          };
+          return XmlEventType.CHARACTERS;
+        }
+
+        const nextCharCode = this.xml.charCodeAt(this.pos + 1);
+        if (nextCharCode === 47) {
+          return this.parseEndTag();
+        }
+        if (nextCharCode === 33) {
+          const cdataType = this.parseBangConstruct();
+          if (cdataType) {
+            return cdataType;
+          }
+          continue;
+        }
+        if (nextCharCode === 63) {
+          this.parseProcessingInstruction();
+          continue;
+        }
+
+        return this.parseStartTag();
+      }
+    } catch (error) {
+      return this.fail(error as Error);
+    }
+  }
+
+  get eventType(): XmlEventType | undefined {
+    return this.currentToken?.type;
+  }
+
+  get name(): string | undefined {
+    return this.currentToken?.name;
+  }
+
+  get localName(): string | undefined {
+    return this.currentToken?.localName;
+  }
+
+  get prefix(): string | undefined {
+    return this.currentToken?.prefix;
+  }
+
+  get uri(): string | undefined {
+    return this.currentToken?.uri;
+  }
+
+  get text(): string | undefined {
+    return this.currentToken?.text;
+  }
+
+  getText(): string {
+    if (this.currentToken?.type !== XmlEventType.CHARACTERS && this.currentToken?.type !== XmlEventType.CDATA) {
+      throw new Error('Current token does not expose text.');
+    }
+
+    return this.currentToken.text;
+  }
+
+  getAttributes(): Record<string, string> {
+    this.assertStartElementToken();
+    return this.attributeCollector.getAttributes();
+  }
+
+  getAttributesWithPrefix(): Record<string, AttributeInfo> {
+    this.assertStartElementToken();
+    return this.attributeCollector.getAttributesWithPrefix();
+  }
+
+  getAttributeValue(rawName: string): string | undefined {
+    this.assertStartElementToken();
+    return this.attributeCollector.getAttributeValue(rawName);
+  }
+
+  private parseStartTag(): XmlEventType {
+    const tagStart = this.pos + 1;
+    const tagEnd = this.findTagEnd(tagStart);
+    if (tagEnd === -1) {
+      throw new Error('Unclosed start tag');
+    }
+
+    let actualEnd = tagEnd;
+    let isSelfClosing = false;
+    if (this.xml.charCodeAt(tagEnd - 1) === 47) {
+      actualEnd = tagEnd - 1;
+      isSelfClosing = true;
+    }
+
+    let nameEnd = tagStart;
+    while (nameEnd < actualEnd) {
+      const code = this.xml.charCodeAt(nameEnd);
+      if (code <= 32) {
+        if (StaxXmlCursorSync.isWhitespace(code)) {
+          break;
+        }
+      } else if (code === 62 || code === 47) {
+        break;
+      }
+      nameEnd++;
+    }
+
+    const tagName = this.xml.slice(tagStart, nameEnd);
+    const namespaces = cloneNamespaces(this.namespaceStack[this.namespaceStack.length - 1]);
+    collectAttributesFromSource(
+      this.xml,
+      nameEnd,
+      actualEnd,
+      namespaces,
+      this.attributeCollector,
+      this.entityDecoder,
+      StaxXmlCursorSync.isWhitespace
+    );
+
+    const nameInfo = resolveElementName(tagName, namespaces);
+    this.currentToken = {
+      type: XmlEventType.START_ELEMENT,
+      ...nameInfo,
+    };
+
+    this.pos = tagEnd + 1;
+
+    if (isSelfClosing) {
+      this.pendingEndElement = nameInfo;
+      return XmlEventType.START_ELEMENT;
+    }
+
+    this.elementStack.push(tagName);
+    this.namespaceStack.push(namespaces);
+    return XmlEventType.START_ELEMENT;
+  }
+
+  private parseEndTag(): XmlEventType {
+    const tagClose = this.findChar(62, this.pos);
+    if (tagClose === -1) {
+      throw new Error('Unclosed end tag');
+    }
+
+    const fullTagName = this.trimmedSlice(this.pos + 2, tagClose);
+    if (this.elementStack.length === 0) {
+      throw new Error(`Mismatched closing tag: </${fullTagName}>. No open elements.`);
+    }
+
+    const expectedTagName = this.elementStack[this.elementStack.length - 1];
+    if (fullTagName !== expectedTagName) {
+      throw new Error(`Mismatched closing tag: </${fullTagName}>. Expected </${expectedTagName}>.`);
+    }
+
+    this.elementStack.pop();
+    const namespaces = this.namespaceStack.pop() ?? new Map<string, string>();
+    this.currentToken = {
+      type: XmlEventType.END_ELEMENT,
+      ...resolveElementName(fullTagName, namespaces),
+    };
+    this.pos = tagClose + 1;
+    return XmlEventType.END_ELEMENT;
+  }
+
+  private parseBangConstruct(): XmlEventType | undefined {
+    if (this.matchesAt('<![CDATA[', this.pos)) {
+      const cdataEnd = this.findSequence(']]>', this.pos + 9);
+      if (cdataEnd === -1) {
+        throw new Error('Unclosed CDATA section');
+      }
+
+      this.currentToken = {
+        type: XmlEventType.CDATA,
+        text: this.xml.slice(this.pos + 9, cdataEnd),
+      };
+      this.pos = cdataEnd + 3;
+      return XmlEventType.CDATA;
+    }
+
+    if (this.matchesAt('<!--', this.pos)) {
+      const commentEnd = this.findSequence('-->', this.pos + 4);
+      if (commentEnd === -1) {
+        throw new Error('Unclosed comment');
+      }
+
+      this.pos = commentEnd + 3;
+      return undefined;
+    }
+
+    if (this.matchesAt('<!DOCTYPE', this.pos)) {
+      const doctypeEnd = this.findChar(62, this.pos);
+      if (doctypeEnd === -1) {
+        throw new Error('Unclosed DOCTYPE declaration');
+      }
+
+      this.pos = doctypeEnd + 1;
+      return undefined;
+    }
+
+    throw new Error(`Malformed XML near position ${this.pos}`);
+  }
+
+  private parseProcessingInstruction(): void {
+    const piEnd = this.findSequence('?>', this.pos);
+    if (piEnd === -1) {
+      throw new Error('Unclosed processing instruction');
+    }
+
+    this.pos = piEnd + 2;
+  }
+
+  private compileEntityDecoder(options: StaxXmlCursorSyncOptions): (text: string) => string {
+    if (options.autoDecodeEntities === false) {
+      return (text) => text;
+    }
+
+    if (options.addEntities && options.addEntities.length > 0) {
+      const entityMap: Record<string, string> = { ...StaxXmlCursorSync.DEFAULT_ENTITY_MAP };
+      const patterns: string[] = ['lt', 'gt', 'quot', 'apos'];
+
+      for (const { entity, value } of options.addEntities) {
+        if (entity && value) {
+          const key = entity.startsWith('&') && entity.endsWith(';')
+            ? entity.slice(1, -1)
+            : entity;
+          entityMap[key] = value;
+          patterns.push(key);
+        }
+      }
+      patterns.push('amp');
+
+      const cacheKey = patterns.join(',');
+      let regex = StaxXmlCursorSync.ENTITY_REGEX_CACHE.get(cacheKey);
+      if (!regex) {
+        const pattern = patterns
+          .sort((left, right) => right.length - left.length)
+          .map((entity) => entity.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+          .join('|');
+        regex = new RegExp(`&(${pattern});`, 'g');
+        StaxXmlCursorSync.ENTITY_REGEX_CACHE.set(cacheKey, regex);
+      }
+
+      return (text: string) => {
+        if (!text || text.indexOf('&') === -1) {
+          return text;
+        }
+        regex.lastIndex = 0;
+        return text.replace(regex, (_, entity) => entityMap[entity] || _);
+      };
+    }
+
+    return (text: string) => {
+      if (!text || text.indexOf('&') === -1) {
+        return text;
+      }
+      StaxXmlCursorSync.DEFAULT_ENTITY_REGEX.lastIndex = 0;
+      return text.replace(
+        StaxXmlCursorSync.DEFAULT_ENTITY_REGEX,
+        (_, entity) => StaxXmlCursorSync.DEFAULT_ENTITY_MAP[entity] || _
+      );
+    };
+  }
+
+  private fail(error: Error): XmlEventType {
+    this.lifecycleState = 'FAILED';
+    this.storedError = error;
+    this.currentToken = undefined;
+    throw error;
+  }
+
+  private assertStartElementToken(): void {
+    if (this.currentToken?.type !== XmlEventType.START_ELEMENT) {
+      throw new Error('Current token does not expose attributes.');
+    }
+  }
+
+  private findChar(targetCode: number, start = this.pos): number {
+    const len16 = this.xmlLength - 15;
+    let i = start;
+
+    for (; i < len16; i += 16) {
+      if (this.xml.charCodeAt(i) === targetCode) return i;
+      if (this.xml.charCodeAt(i + 1) === targetCode) return i + 1;
+      if (this.xml.charCodeAt(i + 2) === targetCode) return i + 2;
+      if (this.xml.charCodeAt(i + 3) === targetCode) return i + 3;
+      if (this.xml.charCodeAt(i + 4) === targetCode) return i + 4;
+      if (this.xml.charCodeAt(i + 5) === targetCode) return i + 5;
+      if (this.xml.charCodeAt(i + 6) === targetCode) return i + 6;
+      if (this.xml.charCodeAt(i + 7) === targetCode) return i + 7;
+      if (this.xml.charCodeAt(i + 8) === targetCode) return i + 8;
+      if (this.xml.charCodeAt(i + 9) === targetCode) return i + 9;
+      if (this.xml.charCodeAt(i + 10) === targetCode) return i + 10;
+      if (this.xml.charCodeAt(i + 11) === targetCode) return i + 11;
+      if (this.xml.charCodeAt(i + 12) === targetCode) return i + 12;
+      if (this.xml.charCodeAt(i + 13) === targetCode) return i + 13;
+      if (this.xml.charCodeAt(i + 14) === targetCode) return i + 14;
+      if (this.xml.charCodeAt(i + 15) === targetCode) return i + 15;
+    }
+
+    for (; i < this.xmlLength; i++) {
+      if (this.xml.charCodeAt(i) === targetCode) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  private matchesAt(value: string, pos: number): boolean {
+    if (pos + value.length > this.xmlLength) {
+      return false;
+    }
+
+    for (let i = 0; i < value.length; i++) {
+      if (this.xml.charCodeAt(pos + i) !== value.charCodeAt(i)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private findTagEnd(start: number): number {
+    let i = start;
+    let inQuote = false;
+    let quoteChar = 0;
+
+    while (i < this.xmlLength) {
+      const code = this.xml.charCodeAt(i);
+      if (code === 34 || code === 39) {
+        if (!inQuote) {
+          inQuote = true;
+          quoteChar = code;
+        } else if (code === quoteChar) {
+          inQuote = false;
+          quoteChar = 0;
+        }
+      } else if (code === 62 && !inQuote) {
+        return i;
+      }
+      i++;
+    }
+
+    return -1;
+  }
+
+  private findSequence(sequence: string, start: number): number {
+    const maxPos = this.xmlLength - sequence.length;
+    for (let i = start; i <= maxPos; i++) {
+      let match = true;
+      for (let j = 0; j < sequence.length; j++) {
+        if (this.xml.charCodeAt(i + j) !== sequence.charCodeAt(j)) {
+          match = false;
+          break;
+        }
+      }
+      if (match) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private trimmedSlice(start: number, end: number): string {
+    while (start < end && StaxXmlCursorSync.isWhitespace(this.xml.charCodeAt(start))) {
+      start++;
+    }
+    while (end > start && StaxXmlCursorSync.isWhitespace(this.xml.charCodeAt(end - 1))) {
+      end--;
+    }
+    return start < end ? this.xml.slice(start, end) : '';
+  }
+
+  private static isWhitespace(code: number): boolean {
+    if (code < 128) {
+      return StaxXmlCursorSync.ASCII_TABLE[code] === 1;
+    }
+    return code <= 32 || StaxXmlCursorSync.UNICODE_WHITESPACE.has(code);
+  }
+}
+
+export default StaxXmlCursorSync;

--- a/packages/stax-xml/src/StaxXmlCursorSync.ts
+++ b/packages/stax-xml/src/StaxXmlCursorSync.ts
@@ -3,6 +3,7 @@ import { AttributeCollector } from './internal/AttributeCollector';
 import {
   cloneNamespaces,
   collectAttributesFromSource,
+  hasNamespaceDeclarationInSource,
   resolveElementName,
   type QualifiedNameInfo,
 } from './internal/XmlCursorParserUtil';
@@ -14,15 +15,6 @@ export interface StaxXmlCursorSyncOptions {
 
 type CursorLifecycleState = 'INITIAL' | 'ACTIVE' | 'DONE' | 'FAILED';
 
-interface CursorToken {
-  type: XmlEventType;
-  name?: string;
-  localName?: string;
-  prefix?: string;
-  uri?: string;
-  text?: string;
-}
-
 export class StaxXmlCursorSync {
   private readonly xml: string;
   private readonly xmlLength: number;
@@ -30,8 +22,16 @@ export class StaxXmlCursorSync {
   private readonly elementStack: string[] = [];
   private readonly namespaceStack: Map<string, string>[] = [new Map<string, string>()];
   private lifecycleState: CursorLifecycleState = 'INITIAL';
-  private currentToken?: CursorToken;
-  private pendingEndElement?: QualifiedNameInfo;
+  private currentType?: XmlEventType;
+  private currentName?: string;
+  private currentLocalName?: string;
+  private currentPrefix?: string;
+  private currentUri?: string;
+  private currentText?: string;
+  private pendingEndName?: string;
+  private pendingEndLocalName?: string;
+  private pendingEndPrefix?: string;
+  private pendingEndUri?: string;
   private storedError?: Error;
 
   private static readonly ASCII_TABLE = (() => {
@@ -90,17 +90,19 @@ export class StaxXmlCursorSync {
     try {
       if (this.lifecycleState === 'INITIAL') {
         this.lifecycleState = 'ACTIVE';
-        this.currentToken = { type: XmlEventType.START_DOCUMENT };
+        this.setCurrentType(XmlEventType.START_DOCUMENT);
         return XmlEventType.START_DOCUMENT;
       }
 
-      if (this.pendingEndElement) {
-        const pending = this.pendingEndElement;
-        this.pendingEndElement = undefined;
-        this.currentToken = {
-          type: XmlEventType.END_ELEMENT,
-          ...pending,
-        };
+      if (this.pendingEndName !== undefined) {
+        this.setCurrent(
+          XmlEventType.END_ELEMENT,
+          this.pendingEndName,
+          this.pendingEndLocalName,
+          this.pendingEndPrefix,
+          this.pendingEndUri
+        );
+        this.clearPendingEnd();
         return XmlEventType.END_ELEMENT;
       }
 
@@ -111,7 +113,7 @@ export class StaxXmlCursorSync {
           }
 
           this.lifecycleState = 'DONE';
-          this.currentToken = { type: XmlEventType.END_DOCUMENT };
+          this.setCurrentType(XmlEventType.END_DOCUMENT);
           return XmlEventType.END_DOCUMENT;
         }
 
@@ -123,10 +125,7 @@ export class StaxXmlCursorSync {
             continue;
           }
 
-          this.currentToken = {
-            type: XmlEventType.CHARACTERS,
-            text: this.entityDecoder(text),
-          };
+          this.setCurrentText(XmlEventType.CHARACTERS, this.entityDecoder(text));
           return XmlEventType.CHARACTERS;
         }
 
@@ -137,10 +136,7 @@ export class StaxXmlCursorSync {
             continue;
           }
 
-          this.currentToken = {
-            type: XmlEventType.CHARACTERS,
-            text: this.entityDecoder(text),
-          };
+          this.setCurrentText(XmlEventType.CHARACTERS, this.entityDecoder(text));
           return XmlEventType.CHARACTERS;
         }
 
@@ -168,35 +164,35 @@ export class StaxXmlCursorSync {
   }
 
   get eventType(): XmlEventType | undefined {
-    return this.currentToken?.type;
+    return this.currentType;
   }
 
   get name(): string | undefined {
-    return this.currentToken?.name;
+    return this.currentName;
   }
 
   get localName(): string | undefined {
-    return this.currentToken?.localName;
+    return this.currentLocalName;
   }
 
   get prefix(): string | undefined {
-    return this.currentToken?.prefix;
+    return this.currentPrefix;
   }
 
   get uri(): string | undefined {
-    return this.currentToken?.uri;
+    return this.currentUri;
   }
 
   get text(): string | undefined {
-    return this.currentToken?.text;
+    return this.currentText;
   }
 
   getText(): string {
-    if (this.currentToken?.type !== XmlEventType.CHARACTERS && this.currentToken?.type !== XmlEventType.CDATA) {
+    if (this.currentType !== XmlEventType.CHARACTERS && this.currentType !== XmlEventType.CDATA) {
       throw new Error('Current token does not expose text.');
     }
 
-    return this.currentToken.text;
+    return this.currentText!;
   }
 
   getAttributes(): Record<string, string> {
@@ -242,7 +238,15 @@ export class StaxXmlCursorSync {
     }
 
     const tagName = this.xml.slice(tagStart, nameEnd);
-    const namespaces = cloneNamespaces(this.namespaceStack[this.namespaceStack.length - 1]);
+    const parentNamespaces = this.namespaceStack[this.namespaceStack.length - 1];
+    const namespaces = hasNamespaceDeclarationInSource(
+      this.xml,
+      nameEnd,
+      actualEnd,
+      StaxXmlCursorSync.isWhitespace
+    )
+      ? cloneNamespaces(parentNamespaces)
+      : parentNamespaces;
     collectAttributesFromSource(
       this.xml,
       nameEnd,
@@ -254,15 +258,12 @@ export class StaxXmlCursorSync {
     );
 
     const nameInfo = resolveElementName(tagName, namespaces);
-    this.currentToken = {
-      type: XmlEventType.START_ELEMENT,
-      ...nameInfo,
-    };
+    this.setCurrentNameInfo(XmlEventType.START_ELEMENT, nameInfo);
 
     this.pos = tagEnd + 1;
 
     if (isSelfClosing) {
-      this.pendingEndElement = nameInfo;
+      this.setPendingEnd(nameInfo);
       return XmlEventType.START_ELEMENT;
     }
 
@@ -289,10 +290,7 @@ export class StaxXmlCursorSync {
 
     this.elementStack.pop();
     const namespaces = this.namespaceStack.pop() ?? new Map<string, string>();
-    this.currentToken = {
-      type: XmlEventType.END_ELEMENT,
-      ...resolveElementName(fullTagName, namespaces),
-    };
+    this.setCurrentNameInfo(XmlEventType.END_ELEMENT, resolveElementName(fullTagName, namespaces));
     this.pos = tagClose + 1;
     return XmlEventType.END_ELEMENT;
   }
@@ -304,10 +302,7 @@ export class StaxXmlCursorSync {
         throw new Error('Unclosed CDATA section');
       }
 
-      this.currentToken = {
-        type: XmlEventType.CDATA,
-        text: this.xml.slice(this.pos + 9, cdataEnd),
-      };
+      this.setCurrentText(XmlEventType.CDATA, this.xml.slice(this.pos + 9, cdataEnd));
       this.pos = cdataEnd + 3;
       return XmlEventType.CDATA;
     }
@@ -323,7 +318,7 @@ export class StaxXmlCursorSync {
     }
 
     if (this.matchesAt('<!DOCTYPE', this.pos)) {
-      const doctypeEnd = this.findChar(62, this.pos);
+      const doctypeEnd = this.findDoctypeEnd(this.pos + 9);
       if (doctypeEnd === -1) {
         throw new Error('Unclosed DOCTYPE declaration');
       }
@@ -399,14 +394,65 @@ export class StaxXmlCursorSync {
   private fail(error: Error): XmlEventType {
     this.lifecycleState = 'FAILED';
     this.storedError = error;
-    this.currentToken = undefined;
+    this.clearCurrent();
     throw error;
   }
 
   private assertStartElementToken(): void {
-    if (this.currentToken?.type !== XmlEventType.START_ELEMENT) {
+    if (this.currentType !== XmlEventType.START_ELEMENT) {
       throw new Error('Current token does not expose attributes.');
     }
+  }
+
+  private clearCurrent(): void {
+    this.currentType = undefined;
+    this.currentName = undefined;
+    this.currentLocalName = undefined;
+    this.currentPrefix = undefined;
+    this.currentUri = undefined;
+    this.currentText = undefined;
+  }
+
+  private clearPendingEnd(): void {
+    this.pendingEndName = undefined;
+    this.pendingEndLocalName = undefined;
+    this.pendingEndPrefix = undefined;
+    this.pendingEndUri = undefined;
+  }
+
+  private setCurrent(
+    type: XmlEventType,
+    name?: string,
+    localName?: string,
+    prefix?: string,
+    uri?: string,
+    text?: string
+  ): void {
+    this.currentType = type;
+    this.currentName = name;
+    this.currentLocalName = localName;
+    this.currentPrefix = prefix;
+    this.currentUri = uri;
+    this.currentText = text;
+  }
+
+  private setCurrentType(type: XmlEventType): void {
+    this.setCurrent(type);
+  }
+
+  private setCurrentText(type: XmlEventType, text: string): void {
+    this.setCurrent(type, undefined, undefined, undefined, undefined, text);
+  }
+
+  private setCurrentNameInfo(type: XmlEventType, nameInfo: QualifiedNameInfo): void {
+    this.setCurrent(type, nameInfo.name, nameInfo.localName, nameInfo.prefix, nameInfo.uri);
+  }
+
+  private setPendingEnd(nameInfo: QualifiedNameInfo): void {
+    this.pendingEndName = nameInfo.name;
+    this.pendingEndLocalName = nameInfo.localName;
+    this.pendingEndPrefix = nameInfo.prefix;
+    this.pendingEndUri = nameInfo.uri;
   }
 
   private findChar(targetCode: number, start = this.pos): number {
@@ -493,6 +539,69 @@ export class StaxXmlCursorSync {
         return i;
       }
     }
+    return -1;
+  }
+
+  private findDoctypeEnd(start: number): number {
+    let position = start;
+    let bracketDepth = 0;
+    let quoteChar = 0;
+    let inComment = false;
+
+    while (position < this.xmlLength) {
+      const currentChar = this.xml.charCodeAt(position);
+
+      if (inComment) {
+        if (this.matchesAt('-->', position)) {
+          inComment = false;
+          position += 3;
+          continue;
+        }
+        position++;
+        continue;
+      }
+
+      if (quoteChar !== 0) {
+        if (currentChar === quoteChar) {
+          quoteChar = 0;
+        }
+        position++;
+        continue;
+      }
+
+      if (currentChar === 34 || currentChar === 39) {
+        quoteChar = currentChar;
+        position++;
+        continue;
+      }
+
+      if (this.matchesAt('<!--', position)) {
+        inComment = true;
+        position += 4;
+        continue;
+      }
+
+      if (currentChar === 91) {
+        bracketDepth++;
+        position++;
+        continue;
+      }
+
+      if (currentChar === 93) {
+        if (bracketDepth > 0) {
+          bracketDepth--;
+        }
+        position++;
+        continue;
+      }
+
+      if (currentChar === 62 && bracketDepth === 0) {
+        return position;
+      }
+
+      position++;
+    }
+
     return -1;
   }
 

--- a/packages/stax-xml/src/StaxXmlParser.ts
+++ b/packages/stax-xml/src/StaxXmlParser.ts
@@ -104,16 +104,16 @@ export class StaxXmlParser implements AsyncIterator<AnyXmlEvent> {
         return XmlEventFactory.endDocument() as EndDocumentEvent;
       case XmlEventType.START_ELEMENT:
         return XmlEventFactory.startElement(
-          this.cursor.name,
+          this.cursor.name!,
           this.cursor.localName,
           this.cursor.prefix,
           this.cursor.uri,
           this.cursor.getAttributes(),
-          this.toLegacyAsyncAttributesWithPrefix()
+          this.toLegacyAsyncAttributesWithPrefix() as unknown as StartElementEvent['attributesWithPrefix']
         ) as StartElementEvent;
       case XmlEventType.END_ELEMENT:
         return XmlEventFactory.endElement(
-          this.cursor.name,
+          this.cursor.name!,
           this.cursor.localName,
           this.cursor.prefix,
           this.cursor.uri

--- a/packages/stax-xml/src/StaxXmlParser.ts
+++ b/packages/stax-xml/src/StaxXmlParser.ts
@@ -55,7 +55,7 @@ export class StaxXmlParser implements AsyncIterator<AnyXmlEvent> {
 
   public async nextBatch(size?: number): Promise<AnyXmlEvent[]> {
     const batch: AnyXmlEvent[] = [];
-    const targetSize = size ?? 1;
+    const targetSize = size ?? this.options.batchSize ?? 1;
     const timeout = this.options.batchTimeout ?? 10;
     const startedAt = Date.now();
 

--- a/packages/stax-xml/src/StaxXmlParser.ts
+++ b/packages/stax-xml/src/StaxXmlParser.ts
@@ -1,1093 +1,146 @@
-// StaxXmlParser.ts - UTF-8 safe version with Boyer-Moore-Horspool and Batch API
 import {
-  AnyXmlEvent,
-  CdataEvent,
-  CharactersEvent,
-  EndDocumentEvent,
-  EndElementEvent,
-  ErrorEvent,
-  StartElementEvent,
-  UnifiedXmlEvent,
-  XmlEventType
+  type AnyXmlEvent,
+  type EndDocumentEvent,
+  type EndElementEvent,
+  type ErrorEvent,
+  type StartDocumentEvent,
+  type StartElementEvent,
+  XmlEventFactory,
+  XmlEventType,
 } from './types';
+import {
+  StaxXmlCursor,
+  type StaxXmlCursorOptions as StaxXmlParserOptions,
+} from './StaxXmlCursor';
 
-/**
- * Configuration options for the StaxXmlParser
- *
- * @public
- */
-export interface StaxXmlParserOptions {
-  /**
-   * Text encoding for the input stream
-   * @defaultValue 'utf-8'
-   */
-  encoding?: string;
+export type { StaxXmlParserOptions };
 
-  /**
-   * Additional custom entities to decode
-   * @defaultValue []
-   */
-  addEntities?: { entity: string, value: string }[];
-
-  /**
-   * Whether to automatically decode XML entities
-   * @defaultValue true
-   */
-  autoDecodeEntities?: boolean;
-
-  /**
-   * Maximum buffer size in bytes
-   * @defaultValue 65536
-   */
-  maxBufferSize?: number;
-
-  /**
-   * Whether to enable buffer compaction for memory efficiency
-   * @defaultValue true
-   */
-  enableBufferCompaction?: boolean;
-
-  /**
-   * Number of events to batch together
-   * @defaultValue 1
-   */
-  batchSize?: number;
-
-  /**
-   * Timeout for batch processing in milliseconds
-   * @defaultValue 0
-   */
-  batchTimeout?: number;
-}
-
-/**
- * High-performance asynchronous XML parser implementing the StAX (Streaming API for XML) pattern.
- *
- * This parser provides memory-efficient processing of large XML files through streaming
- * with support for pull-based parsing, custom entity handling, and namespace processing.
- *
- * @remarks
- * The parser uses UTF-8 safe processing with Boyer-Moore-Horspool pattern search optimization
- * and supports both single-event and batch processing modes for improved performance.
- *
- * @example
- * Basic usage:
- * ```typescript
- * const xmlContent = '<root><item>Hello</item></root>';
- * const stream = new ReadableStream({
- *   start(controller) {
- *     controller.enqueue(new TextEncoder().encode(xmlContent));
- *     controller.close();
- *   }
- * });
- *
- * const parser = new StaxXmlParser(stream);
- * for await (const event of parser) {
- *   console.log(event.type, event);
- * }
- * ```
- *
- * @example
- * With custom options:
- * ```typescript
- * const options = {
- *   autoDecodeEntities: true,
- *   maxBufferSize: 128 * 1024,
- *   addEntities: [{ entity: 'custom', value: 'replacement' }]
- * };
- * const parser = new StaxXmlParser(stream, options);
- * ```
- *
- * @public
- */
 export class StaxXmlParser implements AsyncIterator<AnyXmlEvent> {
-  private reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
-  private readonly decoder: TextDecoder;
-  private buffer: Uint8Array;
-  private bufferLength: number = 0;
-  private position: number = 0;
-  private eventQueue: AnyXmlEvent[] = [];
-  private resolveNext: ((value: IteratorResult<AnyXmlEvent>) => void) | null = null;
-  private error: Error | null = null;
-  private isStreamEnded: boolean = false;
-  private parserFinished: boolean = false;
-  private currentTextBuffer: string = '';
-  private elementStack: string[] = [];
-  private namespaceStack: Map<string, string>[] = [];
+  private readonly cursor: StaxXmlCursor;
   private readonly options: StaxXmlParserOptions;
+  private done = false;
 
-  // ===== Optimization tables and caches =====
-
-  // ASCII character fast classification table (actually used)
-  private static readonly ASCII_TABLE = (() => {
-    const table = new Uint8Array(128);
-    // Whitespace characters: 1
-    table[9] = 1;   // TAB
-    table[10] = 1;  // LF
-    table[13] = 1;  // CR
-    table[32] = 1;  // SPACE
-    // XML special characters: 2-12
-    table[60] = 2;  // '<'
-    table[62] = 3;  // '>'
-    table[47] = 4;  // '/'
-    table[61] = 5;  // '='
-    table[33] = 6;  // '!'
-    table[63] = 7;  // '?'
-    table[34] = 8;  // '"'
-    table[39] = 9;  // "'"
-    table[38] = 10; // '&'
-    table[91] = 11; // '['
-    table[93] = 12; // ']'
-    return table;
-  })();
-
-  // Entity regex cache
-  private static readonly ENTITY_REGEX_CACHE = new Map<string, RegExp>();
-  private static readonly DEFAULT_ENTITY_REGEX = /&(lt|gt|quot|apos|amp);/g;
-  private static readonly DEFAULT_ENTITY_MAP: Record<string, string> = {
-    'lt': '<', 'gt': '>', 'quot': '"', 'apos': "'", 'amp': '&'
-  };
-
-  // Compiled entity decoder
-  private readonly entityDecoder: (text: string) => string;
-
-  // Boyer-Moore-Horspool pattern cache
-  private readonly bmhCache = new Map<string, Uint8Array>();
-
-  // Batch processing state
-  private batchMetrics = {
-    avgEventSize: 100,
-    lastBatchTime: 0,
-    eventCount: 0
-  };
-
-  /**
-   * Creates a new StaxXmlParser instance.
-   *
-   * @param xmlStream - The ReadableStream containing XML data as Uint8Array chunks
-   * @param options - Configuration options for the parser
-   * @throws {Error} When xmlStream is not a valid ReadableStream
-   *
-   * @example
-   * ```typescript
-   * const xmlData = '<root><item>content</item></root>';
-   * const stream = new ReadableStream({
-   *   start(controller) {
-   *     controller.enqueue(new TextEncoder().encode(xmlData));
-   *     controller.close();
-   *   }
-   * });
-   *
-   * const parser = new StaxXmlParser(stream, {
-   *   autoDecodeEntities: true,
-   *   maxBufferSize: 64 * 1024
-   * });
-   * ```
-   */
   constructor(xmlStream: ReadableStream<Uint8Array>, options: StaxXmlParserOptions = {}) {
-    if (!(xmlStream instanceof ReadableStream)) {
-      throw new Error('xmlStream must be a web standard ReadableStream.');
-    }
-
     this.options = {
-      encoding: 'utf-8',
-      autoDecodeEntities: true,
-      maxBufferSize: 64 * 1024,
-      enableBufferCompaction: true,
       batchSize: 10,
       batchTimeout: 10,
-      ...options
+      ...options,
     };
-
-    // TextDecoder optimization settings
-    this.decoder = new TextDecoder(this.options.encoding, {
-      fatal: false,    // Use replacement character � instead of error
-      ignoreBOM: true  // Ignore BOM
-    });
-
-    this.buffer = new Uint8Array(this.options.maxBufferSize || 64 * 1024);
-
-    // Pre-compile entity decoder
-    this.entityDecoder = this._compileEntityDecoder();
-
-    this.reader = xmlStream.getReader();
-    this._startReading();
-    // Inline START_DOCUMENT creation - maintains V8 hidden class optimization
-    this._addEvent({
-      type: XmlEventType.START_DOCUMENT,
-      name: undefined,
-      localName: undefined,
-      prefix: undefined,
-      uri: undefined,
-      attributes: undefined,
-      attributesWithPrefix: undefined,
-      value: undefined,
-      error: undefined
-    } as UnifiedXmlEvent as StartElementEvent);
+    this.cursor = new StaxXmlCursor(xmlStream, this.options);
   }
 
-  // ===== ASCII table utility methods =====
+  public async next(): Promise<IteratorResult<AnyXmlEvent>> {
+    if (this.done) {
+      return { value: undefined, done: true };
+    }
 
-  /**
-   * Fast XML special character check
-   */
-  private getXmlCharType(byte: number): number {
-    return byte < 128 ? StaxXmlParser.ASCII_TABLE[byte] : 0;
-  }
-
-  // ===== UTF-8 safety methods =====
-
-  /**
-   * Check if UTF-8 byte is the start of a character
-   * @param byte The byte to check
-   * @returns true if it's the start of a character
-   */
-  private isUtf8CharStart(byte: number): boolean {
-    // ASCII (0xxxxxxx) or multibyte start (11xxxxxx)
-    // Not a continuation byte (10xxxxxx)
-    return (byte & 0x80) === 0 || (byte & 0xC0) === 0xC0;
-  }
-
-  /**
-   * Calculate UTF-8 sequence length
-   * @param byte The first byte
-   * @returns Sequence length (1-4)
-   */
-  private getUtf8SequenceLength(byte: number): number {
-    if ((byte & 0x80) === 0) return 1;        // 0xxxxxxx
-    if ((byte & 0xE0) === 0xC0) return 2;      // 110xxxxx
-    if ((byte & 0xF0) === 0xE0) return 3;      // 1110xxxx
-    if ((byte & 0xF8) === 0xF0) return 4;      // 11110xxx
-    return 1; // Invalid sequence
-  }
-
-  /**
-   * Safely adjust position at UTF-8 character boundaries
-   * @param pos The position to adjust
-   * @param searchBackward Whether to search backwards
-   * @returns Safe UTF-8 boundary position
-   */
-  private findSafeUtf8Boundary(pos: number, searchBackward: boolean = true): number {
-    if (pos <= 0 || pos >= this.bufferLength) return pos;
-
-    if (searchBackward) {
-      // Search backwards to find character start
-      let safePos = pos;
-      let backtrack = 0;
-
-      while (safePos > 0 && backtrack < 4) {
-        if (this.isUtf8CharStart(this.buffer[safePos])) {
-          // Check if the sequence starting at this position includes the original pos
-          const seqLen = this.getUtf8SequenceLength(this.buffer[safePos]);
-          if (safePos + seqLen > pos) {
-            // pos is in the middle of this character, return safePos
-            return safePos;
-          } else {
-            // pos is already at a safe boundary
-            return pos;
-          }
-        }
-        safePos--;
-        backtrack++;
+    try {
+      const tokenType = await this.cursor.next();
+      const event = this.materializeEvent(tokenType);
+      if (tokenType === XmlEventType.END_DOCUMENT) {
+        this.done = true;
       }
-      return pos; // Could not find appropriate boundary
-    } else {
-      // Search forward to find next character start
-      while (pos < this.bufferLength && !this.isUtf8CharStart(this.buffer[pos])) {
-        pos++;
-      }
-      return pos;
-    }
-  }
-
-  /**
-   * Safely extract UTF-8 string from buffer
-   * @param start Starting position
-   * @param end Ending position
-   * @returns Decoded string
-   */
-  private safeDecodeRange(start: number, end: number): string {
-    // Adjust start and end to safe boundaries
-    const safeStart = this.findSafeUtf8Boundary(start, false);
-    const safeEnd = this.findSafeUtf8Boundary(end, true);
-
-    if (safeStart >= safeEnd) return '';
-
-    return this.decoder.decode(
-      this.buffer.subarray(safeStart, safeEnd),
-      { stream: false }
-    );
-  }
-
-  // ===== Boyer-Moore-Horspool pattern search implementation =====
-
-  /**
-   * Build Boyer-Moore-Horspool bad character table
-   */
-  private _buildBMHTable(pattern: Uint8Array): Uint8Array {
-    const table = new Uint8Array(256);
-    const patternLength = pattern.length;
-
-    table.fill(patternLength);
-
-    for (let i = 0; i < patternLength - 1; i++) {
-      table[pattern[i]] = patternLength - 1 - i;
-    }
-
-    return table;
-  }
-
-  /**
-   * Pattern search using Boyer-Moore-Horspool algorithm
-   * XML delimiters are all ASCII, so no UTF-8 boundary issues
-   */
-  private _findPatternBMH(pattern: string, startPos?: number): number {
-    const patternBytes = new TextEncoder().encode(pattern);
-    const patternLength = patternBytes.length;
-
-    if (patternLength === 0) return -1;
-
-    if (patternLength === 1) {
-      return this._findSingleByte(patternBytes[0], startPos);
-    }
-
-    let skipTable = this.bmhCache.get(pattern);
-    if (!skipTable) {
-      skipTable = this._buildBMHTable(patternBytes);
-      if (this.bmhCache.size > 20) {
-        // Cache size limit
-        this.bmhCache.clear();
-      }
-      this.bmhCache.set(pattern, skipTable);
-    }
-
-    const start = startPos || this.position;
-    const bufferEnd = this.bufferLength - patternLength;
-    let pos = start;
-
-    while (pos <= bufferEnd) {
-      let i = patternLength - 1;
-      while (i >= 0 && this.buffer[pos + i] === patternBytes[i]) {
-        i--;
-      }
-
-      if (i < 0) {
-        return pos;
-      }
-
-      pos += skipTable[this.buffer[pos + patternLength - 1]];
-    }
-
-    return -1;
-  }
-
-  /**
-   * Single byte search (optimized)
-   */
-  private _findSingleByte(byte: number, startPos?: number): number {
-    const start = startPos || this.position;
-    const buffer = this.buffer;
-    const end = this.bufferLength;
-
-    const end4 = end - 3;
-    let i = start;
-
-    for (; i < end4; i += 4) {
-      if (buffer[i] === byte) return i;
-      if (buffer[i + 1] === byte) return i + 1;
-      if (buffer[i + 2] === byte) return i + 2;
-      if (buffer[i + 3] === byte) return i + 3;
-    }
-
-    for (; i < end; i++) {
-      if (buffer[i] === byte) return i;
-    }
-
-    return -1;
-  }
-
-  // ===== Entity decoder compilation =====
-
-  private _compileEntityDecoder(): (text: string) => string {
-    if (!this.options.autoDecodeEntities) {
-      return (text) => text;
-    }
-
-    if (this.options.addEntities && this.options.addEntities.length > 0) {
-      const entityMap: Record<string, string> = { ...StaxXmlParser.DEFAULT_ENTITY_MAP };
-      const patterns: string[] = ['lt', 'gt', 'quot', 'apos'];
-
-      for (const { entity, value } of this.options.addEntities) {
-        if (entity && value) {
-          const key = entity.startsWith('&') && entity.endsWith(';')
-            ? entity.slice(1, -1)
-            : entity;
-          entityMap[key] = value;
-          patterns.push(key);
-        }
-      }
-      patterns.push('amp');
-
-      const cacheKey = patterns.join(',');
-      let regex = StaxXmlParser.ENTITY_REGEX_CACHE.get(cacheKey);
-
-      if (!regex) {
-        const pattern = patterns
-          .sort((a, b) => b.length - a.length)
-          .map(e => e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-          .join('|');
-        regex = new RegExp(`&(${pattern});`, 'g');
-        StaxXmlParser.ENTITY_REGEX_CACHE.set(cacheKey, regex);
-      }
-
-      return (text: string) => {
-        if (!text || text.indexOf('&') === -1) return text;
-        regex!.lastIndex = 0;
-        return text.replace(regex!, (_, entity) => entityMap[entity] || _);
+      return {
+        value: event,
+        done: false,
+      };
+    } catch (error) {
+      this.done = true;
+      return {
+        value: XmlEventFactory.error(error as Error) as ErrorEvent,
+        done: false,
       };
     }
-
-    return (text: string) => {
-      if (!text || text.indexOf('&') === -1) return text;
-      StaxXmlParser.DEFAULT_ENTITY_REGEX.lastIndex = 0;
-      return text.replace(
-        StaxXmlParser.DEFAULT_ENTITY_REGEX,
-        (_, entity) => StaxXmlParser.DEFAULT_ENTITY_MAP[entity] || _
-      );
-    };
-  }
-
-  // ===== Batch processing API =====
-
-  private _calculateOptimalBatchSize(): number {
-    const MIN_BATCH = 1;
-    const MAX_BATCH = this.options.batchSize || 10;
-
-    if (this.bufferLength < 1024) return MIN_BATCH;
-    if (this.bufferLength > 10240) return MAX_BATCH;
-
-    if (this.eventQueue.length > 0) {
-      const lastEvent = this.eventQueue[this.eventQueue.length - 1];
-      if (lastEvent?.type === XmlEventType.CHARACTERS) {
-        return MIN_BATCH;
-      }
-    }
-
-    if (this.batchMetrics.eventCount > 100) {
-      const avgSize = this.batchMetrics.avgEventSize;
-      if (avgSize > 1000) return MIN_BATCH;
-      if (avgSize < 100) return MAX_BATCH;
-    }
-
-    return Math.min(MAX_BATCH, Math.max(MIN_BATCH, Math.floor(this.bufferLength / 1024)));
   }
 
   public async nextBatch(size?: number): Promise<AnyXmlEvent[]> {
     const batch: AnyXmlEvent[] = [];
-    const targetSize = size || this._calculateOptimalBatchSize();
-    const startTime = Date.now();
-    const timeout = this.options.batchTimeout || 10;
+    const targetSize = size ?? 1;
+    const timeout = this.options.batchTimeout ?? 10;
+    const startedAt = Date.now();
 
     for (let i = 0; i < targetSize; i++) {
-      if (Date.now() - startTime > timeout) {
+      if (Date.now() - startedAt > timeout) {
         break;
       }
 
       const result = await this.next();
-      if (result.done) break;
+      if (result.done) {
+        break;
+      }
+
       batch.push(result.value);
+      if (result.value.type === XmlEventType.ERROR) {
+        break;
+      }
     }
 
     return batch;
   }
 
   public async *batchedIterator(batchSize?: number): AsyncGenerator<AnyXmlEvent[]> {
-    while (!this.parserFinished || this.eventQueue.length > 0) {
-      const targetSize = batchSize || this._calculateOptimalBatchSize();
-      const batch = await this.nextBatch(targetSize);
-      if (batch.length === 0) break;
-      yield batch;
-    }
-  }
-
-  // ===== Improved buffer management =====
-
-  private _compactBufferIfNeeded(): void {
-    if (!this.options.enableBufferCompaction) return;
-
-    const maxSize = this.options.maxBufferSize || 64 * 1024;
-
-    const shouldCompact =
-      (this.position > 8192 && this.bufferLength > 16384) ||
-      (this.position > maxSize / 2) ||
-      (this.bufferLength > maxSize && this.position > maxSize / 4);
-
-    if (shouldCompact) {
-      this._compactBuffer();
-    }
-  }
-
-  private _compactBuffer(): void {
-    if (this.position > 0 && this.position < this.bufferLength) {
-      // Check UTF-8 boundaries
-      const safePos = this.findSafeUtf8Boundary(this.position, true);
-
-      const remainingLength = this.bufferLength - safePos;
-
-      if (remainingLength < safePos) {
-        const newBuffer = new Uint8Array(this.buffer.length);
-        newBuffer.set(this.buffer.subarray(safePos, this.bufferLength));
-        this.buffer = newBuffer;
-      } else {
-        this.buffer.copyWithin(0, safePos, this.bufferLength);
-      }
-
-      this.bufferLength = remainingLength;
-      this.position = this.position - safePos;
-
-      if (this.bmhCache.size > 20) {
-        this.bmhCache.clear();
-      }
-    }
-  }
-
-  // ===== Main parsing logic =====
-
-  private async _startReading(): Promise<void> {
-    try {
-      while (true) {
-        const { done, value } = await this.reader!.read();
-
-        if (done) {
-          this.isStreamEnded = true;
-          this._parseBuffer();
-
-          if (!this.parserFinished && this.elementStack.length > 0) {
-            this._addError(new Error('Unexpected end of document. Not all elements were closed.'));
-          }
-
-          if (!this.parserFinished) {
-            this._flushCharacters();
-            // Inline END_DOCUMENT creation - maintains V8 hidden class optimization
-            this._addEvent({
-              type: XmlEventType.END_DOCUMENT,
-              name: undefined,
-              localName: undefined,
-              prefix: undefined,
-              uri: undefined,
-              attributes: undefined,
-              attributesWithPrefix: undefined,
-              value: undefined,
-              error: undefined
-            } as UnifiedXmlEvent as EndDocumentEvent);
-            this.parserFinished = true;
-          }
-
-          if (this.resolveNext && this.eventQueue.length === 0) {
-            this.resolveNext({ value: undefined, done: true });
-            this.resolveNext = null;
-          }
-          break;
-        }
-
-        this._appendToBuffer(value);
-        this._parseBuffer();
-        this._compactBufferIfNeeded();
-        this._updateBatchMetrics(value.length);
-      }
-    } catch (err) {
-      this._addError(err as Error);
-      if (this.resolveNext) {
-        this.resolveNext({ value: undefined, done: true });
-        this.resolveNext = null;
-      }
-    }
-  }
-
-  private _updateBatchMetrics(bytesProcessed: number): void {
-    const eventsDelta = this.eventQueue.length;
-    if (eventsDelta > 0) {
-      this.batchMetrics.eventCount += eventsDelta;
-      this.batchMetrics.avgEventSize =
-        (this.batchMetrics.avgEventSize * 0.9) +
-        ((bytesProcessed / eventsDelta) * 0.1);
-    }
-    this.batchMetrics.lastBatchTime = Date.now();
-  }
-
-  private _parseBuffer(): void {
-    while (this.position < this.bufferLength && !this.parserFinished) {
-      const ltPos = this._findSingleByte(60, this.position); // '<'
-
-      if (ltPos === -1) {
-        if (this.isStreamEnded) {
-          const remainingText = this._readBuffer();
-          this.currentTextBuffer += remainingText;
-          this._flushCharacters();
-        }
+    while (!this.done) {
+      const batch = await this.nextBatch(batchSize);
+      if (batch.length === 0) {
         break;
       }
-
-      if (ltPos > this.position) {
-        try {
-          const textLength = ltPos - this.position;
-          const text = this._readBuffer(textLength);
-          this.currentTextBuffer += text;
-        } catch (error) {
-          if (!this.isStreamEnded) break;
-          throw error;
-        }
-      }
-
-      this.position = ltPos;
-
-      // Fast tag type identification using ASCII table
-      const nextByte = this.buffer[this.position + 1];
-      const charType = this.getXmlCharType(nextByte);
-
-      if (charType === 4) { // '/' (47)
-        this._flushCharacters();
-        if (!this._parseEndTag()) break;
-      } else if (charType === 6) { // '!' (33)
-        if (this._matchesPattern('<!--')) {
-          if (!this._parseComment()) break;
-        } else if (this._matchesPattern('<![CDATA[')) {
-          if (!this._parseCData()) break;
-        } else {
-          if (this.isStreamEnded) {
-            this._addError(new Error(`Malformed XML near position ${this.position}`));
-            return;
-          }
-          break;
-        }
-      } else if (charType === 7) { // '?' (63)
-        if (this._matchesPattern('<?xml')) {
-          if (!this._parseXmlDeclaration()) break;
-        } else if (this._matchesPattern('<?')) {
-          if (!this._parseProcessingInstruction()) break;
-        }
-      } else {
-        this._flushCharacters();
-        if (!this._parseStartTag()) break;
-      }
-
-      this._compactBufferIfNeeded();
+      yield batch;
     }
-  }
-
-  private _flushCharacters(): void {
-    if (this.currentTextBuffer.length > 0) {
-      const decodedText = this.entityDecoder(this.currentTextBuffer);
-
-      if (decodedText.trim().length > 0) {
-        // Inline CHARACTERS creation - maintains V8 hidden class optimization
-        this._addEvent({
-          type: XmlEventType.CHARACTERS,
-          name: undefined,
-          localName: undefined,
-          prefix: undefined,
-          uri: undefined,
-          attributes: undefined,
-          attributesWithPrefix: undefined,
-          value: decodedText,
-          error: undefined
-        } as UnifiedXmlEvent as CharactersEvent);
-      }
-      this.currentTextBuffer = '';
-    }
-  }
-
-  private _clearBuffers(): void {
-    this.bufferLength = 0;
-    this.position = 0;
-    this.currentTextBuffer = '';
-    this.bmhCache.clear();
-  }
-
-  private _addEvent(event: AnyXmlEvent): void {
-    this.eventQueue.push(event);
-    if (this.resolveNext) {
-      this.resolveNext(this._popNextEvent() as IteratorResult<AnyXmlEvent>);
-      this.resolveNext = null;
-    }
-  }
-
-  private _addError(err: Error): void {
-    if (this.error === null) {
-      this.error = err;
-      // Inline ERROR creation - maintains V8 hidden class optimization
-      this._addEvent({
-        type: XmlEventType.ERROR,
-        name: undefined,
-        localName: undefined,
-        prefix: undefined,
-        uri: undefined,
-        attributes: undefined,
-        attributesWithPrefix: undefined,
-        value: undefined,
-        error: err
-      } as UnifiedXmlEvent as ErrorEvent);
-      this.parserFinished = true;
-      this._clearBuffers();
-
-      if (this.reader) {
-        this.reader.releaseLock();
-        this.reader = null;
-      }
-    }
-  }
-
-  private _popNextEvent(): IteratorResult<AnyXmlEvent> | null {
-    if (this.eventQueue.length > 0) {
-      return { value: this.eventQueue.shift()!, done: false };
-    }
-    if (this.parserFinished) {
-      return { value: undefined, done: true };
-    }
-    return null;
-  }
-
-  public async next(): Promise<IteratorResult<AnyXmlEvent>> {
-    if (this.error) {
-      throw this.error;
-    }
-
-    const nextEvent = this._popNextEvent();
-    if (nextEvent) {
-      return nextEvent;
-    }
-
-    if (this.parserFinished) {
-      return { value: undefined, done: true };
-    }
-
-    return new Promise((resolve) => {
-      this.resolveNext = resolve;
-    });
   }
 
   public [Symbol.asyncIterator](): AsyncIterator<AnyXmlEvent> {
     return this;
   }
 
-  private _appendToBuffer(newData: Uint8Array): void {
-    const requiredSize = this.bufferLength + newData.length;
-
-    if (requiredSize > this.buffer.length) {
-      const newSize = Math.max(this.buffer.length * 2, requiredSize);
-      const newBuffer = new Uint8Array(newSize);
-      newBuffer.set(this.buffer.subarray(0, this.bufferLength));
-      this.buffer = newBuffer;
-    }
-
-    this.buffer.set(newData, this.bufferLength);
-    this.bufferLength += newData.length;
-  }
-
-  /**
-   * UTF-8 safe buffer reading
-   */
-  private _readBuffer(length?: number): string {
-    const originalPos = this.position;
-    let endPos = length ? Math.min(this.position + length, this.bufferLength) : this.bufferLength;
-
-    // If specified length exists and is in the middle of buffer, check UTF-8 boundaries
-    if (length && endPos < this.bufferLength) {
-      endPos = this.findSafeUtf8Boundary(endPos, true);
-    }
-
-    const slice = this.buffer.subarray(this.position, endPos);
-
-    try {
-      const result = this.decoder.decode(slice, { stream: !this.isStreamEnded });
-      this.position = endPos;
-      return result;
-    } catch (error) {
-      // Handle incomplete UTF-8 sequences
-      if (!this.isStreamEnded && endPos === this.bufferLength) {
-        // Backtrack up to the last 4 bytes
-        for (let i = 1; i <= 4 && endPos - i > this.position; i++) {
-          const testEnd = this.findSafeUtf8Boundary(endPos - i, true);
-          if (testEnd > this.position) {
-            try {
-              const safeSlice = this.buffer.subarray(this.position, testEnd);
-              const result = this.decoder.decode(safeSlice, { stream: true });
-              this.position = testEnd;
-              return result;
-            } catch {
-              continue;
-            }
-          }
-        }
-      }
-      this.position = originalPos;
-      throw error;
-    }
-  }
-
-  private _matchesPattern(pattern: string): boolean {
-    const patternBytes = new TextEncoder().encode(pattern);
-    if (this.position + patternBytes.length > this.bufferLength) {
-      return false;
-    }
-
-    for (let i = 0; i < patternBytes.length; i++) {
-      if (this.buffer[this.position + i] !== patternBytes[i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-
-  private _parseXmlDeclaration(): boolean {
-    const endPos = this._findPatternBMH('?>');
-    if (endPos === -1) return false;
-    this.position = endPos + 2;
-    return true;
-  }
-
-  private _parseComment(): boolean {
-    const endPos = this._findPatternBMH('-->');
-    if (endPos === -1) return false;
-    this.position = endPos + 3;
-    return true;
-  }
-
-  /**
-   * UTF-8 safe CDATA parsing
-   */
-  private _parseCData(): boolean {
-    const startPos = this.position + 9; // After '<![CDATA['
-    const endPos = this._findPatternBMH(']]>');
-    if (endPos === -1) return false;
-
-    try {
-      // Check UTF-8 boundaries
-      const safeStart = this.findSafeUtf8Boundary(startPos, false);
-      const safeEnd = this.findSafeUtf8Boundary(endPos, true);
-
-      const cdataContent = this.decoder.decode(
-        this.buffer.subarray(safeStart, safeEnd),
-        { stream: false }
-      );
-
-      // Inline CDATA creation - maintains V8 hidden class optimization
-      this._addEvent({
-        type: XmlEventType.CDATA,
-        name: undefined,
-        localName: undefined,
-        prefix: undefined,
-        uri: undefined,
-        attributes: undefined,
-        attributesWithPrefix: undefined,
-        value: cdataContent,
-        error: undefined
-      } as UnifiedXmlEvent as CdataEvent);
-
-      this.position = endPos + 3;
-      return true;
-    } catch (error) {
-      if (!this.isStreamEnded) return false;
-      throw error;
-    }
-  }
-
-  private _parseProcessingInstruction(): boolean {
-    const endPos = this._findPatternBMH('?>');
-    if (endPos === -1) return false;
-    this.position = endPos + 2;
-    return true;
-  }
-
-  /**
-   * UTF-8 safe end tag parsing
-   */
-  private _parseEndTag(): boolean {
-    const gtPos = this._findSingleByte(62, this.position); // '>'
-    if (gtPos === -1) return false;
-
-    try {
-      // Safely decode the entire tag
-      const tagContent = this.safeDecodeRange(this.position, gtPos + 1);
-      const closeTagMatch = tagContent.match(/^<\/([a-zA-Z0-9_:.\-\u0080-\uFFFF]+)\s*>$/);
-
-      if (!closeTagMatch) {
-        this._addError(new Error('Malformed closing tag'));
-        return true;
-      }
-
-      const tagName = closeTagMatch[1];
-      if (this.elementStack.length === 0 || this.elementStack[this.elementStack.length - 1] !== tagName) {
-        this._addError(new Error(`Mismatched closing tag: </${tagName}>. Expected </${this.elementStack[this.elementStack.length - 1] || 'nothing'}>`));
-        return true;
-      }
-
-      const currentNamespaces = this.namespaceStack.length > 0 ?
-        this.namespaceStack[this.namespaceStack.length - 1] : new Map();
-      const { localName, prefix, uri } = this._parseQualifiedName(tagName, currentNamespaces);
-
-      this.elementStack.pop();
-      this.namespaceStack.pop();
-
-      // Inline END_ELEMENT creation - maintains V8 hidden class optimization
-      this._addEvent({
-        type: XmlEventType.END_ELEMENT,
-        name: tagName,
-        localName,
-        prefix,
-        uri,
-        attributes: undefined,
-        attributesWithPrefix: undefined,
-        value: undefined,
-        error: undefined
-      } as UnifiedXmlEvent as EndElementEvent);
-
-      this.position = gtPos + 1;
-      return true;
-    } catch (error) {
-      if (!this.isStreamEnded) return false;
-      throw error;
-    }
-  }
-
-  /**
-   * UTF-8 safe start tag parsing (using ASCII table)
-   */
-  private _parseStartTag(): boolean {
-    const gtPos = this._findSingleByte(62, this.position); // '>'
-    if (gtPos === -1) return false;
-
-    try {
-      // Safely decode the entire tag
-      const tagContent = this.safeDecodeRange(this.position, gtPos + 1);
-      const tagMatch = tagContent.match(/^<([a-zA-Z0-9_:.\-\u0080-\uFFFF]+)(\s+[^>]*?)?\s*(\/?)>$/);
-
-      if (!tagMatch) {
-        this._addError(new Error('Malformed start tag'));
-        return true;
-      }
-
-      const tagName = tagMatch[1];
-      const attributesString = tagMatch[2] || '';
-      const isSelfClosing = tagMatch[3] === '/';
-
-      const currentNamespaces = new Map<string, string>();
-      if (this.namespaceStack.length > 0) {
-        const parentNamespaces = this.namespaceStack[this.namespaceStack.length - 1];
-        for (const [prefix, uri] of parentNamespaces) {
-          currentNamespaces.set(prefix, uri);
-        }
-      }
-
-      const attributes: { [key: string]: string } = {};
-      const attributesWithPrefix: { [key: string]: { value: string; prefix?: string; uri?: string } } = {};
-
-      // Attribute parsing - Unicode character support
-      const attrRegex = /([a-zA-Z0-9_:.\-\u0080-\uFFFF]+)(?:\s*=\s*"([^"]*)"|\s*=\s*'([^']*)')?/g;
-      let attrMatch;
-
-      while ((attrMatch = attrRegex.exec(attributesString)) !== null) {
-        const attrName = attrMatch[1];
-        const attrValue = this.entityDecoder(attrMatch[2] || attrMatch[3] || 'true');
-        attributes[attrName] = attrValue;
-
-        const attrNamespaceInfo = this._parseQualifiedName(attrName, currentNamespaces, true);
-        attributesWithPrefix[attrNamespaceInfo.localName] = {
-          value: attrValue,
-          prefix: attrNamespaceInfo.prefix,
-          uri: attrNamespaceInfo.uri
-        };
-
-        if (attrName === 'xmlns') {
-          currentNamespaces.set('', attrValue);
-        } else if (attrName.startsWith('xmlns:')) {
-          const prefix = attrName.substring(6);
-          currentNamespaces.set(prefix, attrValue);
-        }
-      }
-
-      const { localName, prefix, uri } = this._parseQualifiedName(tagName, currentNamespaces);
-
-      // Inline START_ELEMENT creation - maintains V8 hidden class optimization
-      this._addEvent({
-        type: XmlEventType.START_ELEMENT,
-        name: tagName,
-        localName,
-        prefix,
-        uri,
-        attributes: attributes,
-        attributesWithPrefix: attributesWithPrefix,
-        value: undefined,
-        error: undefined
-      } as UnifiedXmlEvent as StartElementEvent);
-
-      this.position = gtPos + 1;
-
-      if (!isSelfClosing) {
-        this.elementStack.push(tagName);
-        this.namespaceStack.push(currentNamespaces);
-      } else {
-        // Inline END_ELEMENT creation for self-closing - maintains V8 hidden class optimization
-        this._addEvent({
-          type: XmlEventType.END_ELEMENT,
-          name: tagName,
-          localName,
-          prefix,
-          uri,
-          attributes: undefined,
-          attributesWithPrefix: undefined,
-          value: undefined,
-          error: undefined
-        } as UnifiedXmlEvent as EndElementEvent);
-      }
-
-      return true;
-    } catch (error) {
-      if (!this.isStreamEnded) return false;
-      throw error;
-    }
-  }
-
-  private _parseQualifiedName(
-    qname: string,
-    namespaces: Map<string, string>,
-    isAttribute: boolean = false
-  ): {
-    localName: string;
-    prefix?: string;
-    uri?: string;
-  } {
-    const colonIndex = qname.indexOf(':');
-    if (colonIndex === -1) {
-      if (isAttribute) {
-        return {
-          localName: qname,
-          prefix: undefined,
-          uri: undefined
-        };
-      } else {
-        const defaultUri = namespaces.get('');
-        return {
-          localName: qname,
-          prefix: undefined,
-          uri: defaultUri
-        };
-      }
-    } else {
-      const prefix = qname.substring(0, colonIndex);
-      const localName = qname.substring(colonIndex + 1);
-      const uri = namespaces.get(prefix);
-      return {
-        localName,
-        prefix,
-        uri
-      };
-    }
-  }
-
   public get XmlEventType(): typeof XmlEventType {
     return XmlEventType;
+  }
+
+  private materializeEvent(tokenType: XmlEventType): AnyXmlEvent {
+    switch (tokenType) {
+      case XmlEventType.START_DOCUMENT:
+        return XmlEventFactory.startDocument() as StartDocumentEvent;
+      case XmlEventType.END_DOCUMENT:
+        return XmlEventFactory.endDocument() as EndDocumentEvent;
+      case XmlEventType.START_ELEMENT:
+        return XmlEventFactory.startElement(
+          this.cursor.name,
+          this.cursor.localName,
+          this.cursor.prefix,
+          this.cursor.uri,
+          this.cursor.getAttributes(),
+          this.toLegacyAsyncAttributesWithPrefix()
+        ) as StartElementEvent;
+      case XmlEventType.END_ELEMENT:
+        return XmlEventFactory.endElement(
+          this.cursor.name,
+          this.cursor.localName,
+          this.cursor.prefix,
+          this.cursor.uri
+        ) as EndElementEvent;
+      case XmlEventType.CHARACTERS:
+        return XmlEventFactory.characters(this.cursor.getText());
+      case XmlEventType.CDATA:
+        return XmlEventFactory.cdata(this.cursor.getText());
+      case XmlEventType.ERROR:
+        return XmlEventFactory.error(new Error('Cursor should not emit ERROR tokens.'));
+      default:
+        throw new Error(`Unsupported token type: ${String(tokenType)}`);
+    }
+  }
+
+  private toLegacyAsyncAttributesWithPrefix(): Record<string, { value: string; prefix?: string; uri?: string }> {
+    const attributesWithPrefix = this.cursor.getAttributesWithPrefix();
+    return Object.fromEntries(
+      Object.values(attributesWithPrefix).map((attribute) => [
+        attribute.localName,
+        {
+          value: attribute.value,
+          prefix: attribute.prefix,
+          uri: attribute.uri,
+        },
+      ])
+    );
   }
 }
 

--- a/packages/stax-xml/src/StaxXmlParserSync.ts
+++ b/packages/stax-xml/src/StaxXmlParserSync.ts
@@ -1,26 +1,80 @@
 import {
   type AnyXmlEvent,
+  type AttributeInfo,
+  type CdataEvent,
+  type CharactersEvent,
   type EndDocumentEvent,
   type EndElementEvent,
-  type ErrorEvent,
-  type StartDocumentEvent,
   type StartElementEvent,
-  XmlEventFactory,
   XmlEventType,
 } from './types';
-import {
-  StaxXmlCursorSync,
-  type StaxXmlCursorSyncOptions,
-} from './StaxXmlCursorSync';
 
-export type { StaxXmlCursorSyncOptions };
+export interface StaxXmlParserSyncOptions {
+  autoDecodeEntities?: boolean;
+  addEntities?: { entity: string, value: string }[];
+}
 
 export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXmlEvent> {
-  private readonly cursor: StaxXmlCursorSync;
+  private readonly xml: string;
+  private readonly xmlLength: number;
+  private pos = 0;
+  private readonly elementStack: string[] = [];
+  private namespaceStack: Map<string, string>[] = [];
+  private readonly options: StaxXmlParserSyncOptions;
+  private internalIterator?: Generator<AnyXmlEvent>;
   private done = false;
 
-  constructor(xml: string, options: StaxXmlCursorSyncOptions = {}) {
-    this.cursor = new StaxXmlCursorSync(xml, options);
+  private static readonly ASCII_TABLE = (() => {
+    const table = new Uint8Array(128);
+    table[9] = 1;
+    table[10] = 1;
+    table[13] = 1;
+    table[32] = 1;
+    table[60] = 2;
+    table[62] = 3;
+    table[47] = 4;
+    table[61] = 5;
+    table[33] = 6;
+    table[63] = 7;
+    table[34] = 8;
+    table[39] = 9;
+    return table;
+  })();
+
+  private static readonly UNICODE_WHITESPACE = new Set([
+    0x00A0,
+    0x1680,
+    0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007, 0x2008, 0x2009, 0x200A,
+    0x2028,
+    0x2029,
+    0x202F,
+    0x205F,
+    0x3000,
+    0xFEFF,
+  ]);
+
+  private static readonly ENTITY_REGEX_CACHE = new Map<string, RegExp>();
+  private static readonly DEFAULT_ENTITY_REGEX = /&(lt|gt|quot|apos|amp);/g;
+  private static readonly DEFAULT_ENTITY_MAP: Record<string, string> = {
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: '\'',
+    amp: '&',
+  };
+
+  private readonly entityDecoder: (text: string) => string;
+
+  constructor(xml: string, options: StaxXmlParserSyncOptions = {}) {
+    this.xml = xml;
+    this.xmlLength = xml.length;
+    this.options = {
+      autoDecodeEntities: true,
+      ...options,
+    };
+
+    this.namespaceStack.push(new Map<string, string>());
+    this.entityDecoder = this.compileEntityDecoder();
   }
 
   public [Symbol.iterator](): Iterator<AnyXmlEvent> {
@@ -32,56 +86,744 @@ export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXml
       return { value: undefined, done: true };
     }
 
+    if (!this.internalIterator) {
+      this.internalIterator = this.internalGenerator();
+    }
+
     try {
-      const tokenType = this.cursor.next();
-      const event = this.materializeEvent(tokenType);
-      if (tokenType === XmlEventType.END_DOCUMENT) {
+      const result = this.internalIterator.next();
+      if (result.done) {
         this.done = true;
       }
-      return {
-        value: event,
-        done: false,
-      };
+      return result;
     } catch (error) {
       this.done = true;
       return {
-        value: XmlEventFactory.error(error as Error) as ErrorEvent,
+        value: {
+          type: XmlEventType.ERROR,
+          name: undefined,
+          localName: undefined,
+          prefix: undefined,
+          uri: undefined,
+          attributes: undefined,
+          attributesWithPrefix: undefined,
+          value: undefined,
+          error: error as Error,
+        } as unknown as AnyXmlEvent,
         done: false,
       };
     }
   }
 
-  private materializeEvent(tokenType: XmlEventType): AnyXmlEvent {
-    switch (tokenType) {
-      case XmlEventType.START_DOCUMENT:
-        return XmlEventFactory.startDocument() as StartDocumentEvent;
-      case XmlEventType.END_DOCUMENT:
-        return XmlEventFactory.endDocument() as EndDocumentEvent;
-      case XmlEventType.START_ELEMENT:
-        return XmlEventFactory.startElement(
-          this.cursor.name,
-          this.cursor.localName,
-          this.cursor.prefix,
-          this.cursor.uri,
-          this.cursor.getAttributes(),
-          this.cursor.getAttributesWithPrefix()
-        ) as StartElementEvent;
-      case XmlEventType.END_ELEMENT:
-        return XmlEventFactory.endElement(
-          this.cursor.name,
-          this.cursor.localName,
-          this.cursor.prefix,
-          this.cursor.uri
-        ) as EndElementEvent;
-      case XmlEventType.CHARACTERS:
-        return XmlEventFactory.characters(this.cursor.getText());
-      case XmlEventType.CDATA:
-        return XmlEventFactory.cdata(this.cursor.getText());
-      case XmlEventType.ERROR:
-        return XmlEventFactory.error(new Error('Cursor should not emit ERROR tokens.'));
-      default:
-        throw new Error(`Unsupported token type: ${String(tokenType)}`);
+  private *internalGenerator(): Generator<AnyXmlEvent> {
+    yield {
+      type: XmlEventType.START_DOCUMENT,
+      name: undefined,
+      localName: undefined,
+      prefix: undefined,
+      uri: undefined,
+      attributes: undefined,
+      attributesWithPrefix: undefined,
+      value: undefined,
+      error: undefined,
+    } as unknown as StartElementEvent;
+
+    while (this.pos < this.xmlLength) {
+      const ltPos = this.findChar(60, this.pos);
+
+      if (ltPos === -1) {
+        if (this.pos < this.xmlLength) {
+          const text = this.trimmedSlice(this.pos, this.xmlLength);
+          if (text) {
+            yield {
+              type: XmlEventType.CHARACTERS,
+              name: undefined,
+              localName: undefined,
+              prefix: undefined,
+              uri: undefined,
+              attributes: undefined,
+              attributesWithPrefix: undefined,
+              value: this.entityDecoder(text),
+              error: undefined,
+            } as unknown as CharactersEvent;
+          }
+        }
+        break;
+      }
+
+      if (ltPos > this.pos) {
+        const text = this.trimmedSlice(this.pos, ltPos);
+        if (text) {
+          yield {
+            type: XmlEventType.CHARACTERS,
+            name: undefined,
+            localName: undefined,
+            prefix: undefined,
+            uri: undefined,
+            attributes: undefined,
+            attributesWithPrefix: undefined,
+            value: this.entityDecoder(text),
+            error: undefined,
+          } as unknown as CharactersEvent;
+        }
+      }
+
+      this.pos = ltPos;
+      const nextCharCode = this.xml.charCodeAt(this.pos + 1);
+
+      switch (nextCharCode) {
+        case 47:
+          yield* this.parseEndTag();
+          break;
+        case 33:
+          yield* this.parseCdataCommentDoctype();
+          break;
+        case 63:
+          yield* this.parseProcessingInstruction();
+          break;
+        default:
+          yield* this.parseStartTag();
+          break;
+      }
     }
+
+    yield {
+      type: XmlEventType.END_DOCUMENT,
+      name: undefined,
+      localName: undefined,
+      prefix: undefined,
+      uri: undefined,
+      attributes: undefined,
+      attributesWithPrefix: undefined,
+      value: undefined,
+      error: undefined,
+    } as unknown as EndDocumentEvent;
+  }
+
+  private *parseEndTag(): Generator<AnyXmlEvent> {
+    const tagClose = this.findChar(62, this.pos);
+    if (tagClose === -1) {
+      throw new Error('Unclosed end tag');
+    }
+
+    const fullTagName = this.trimmedSlice(this.pos + 2, tagClose);
+
+    if (this.elementStack.length === 0) {
+      throw new Error(`Mismatched closing tag: </${fullTagName}>. No open elements.`);
+    }
+
+    const expectedTagName = this.elementStack[this.elementStack.length - 1];
+    if (fullTagName !== expectedTagName) {
+      throw new Error(`Mismatched closing tag: </${fullTagName}>. Expected </${expectedTagName}>.`);
+    }
+
+    this.elementStack.pop();
+    const currentNamespaces = this.namespaceStack.pop();
+
+    const colonIndex = fullTagName.indexOf(':');
+    let localName: string;
+    let prefix: string | undefined;
+    let uri: string | undefined;
+
+    if (colonIndex === -1) {
+      localName = fullTagName;
+      prefix = undefined;
+      uri = currentNamespaces ? currentNamespaces.get('') : undefined;
+    } else {
+      prefix = fullTagName.slice(0, colonIndex);
+      localName = fullTagName.slice(colonIndex + 1);
+      uri = currentNamespaces ? currentNamespaces.get(prefix) : undefined;
+    }
+
+    yield {
+      type: XmlEventType.END_ELEMENT,
+      name: fullTagName,
+      localName,
+      prefix,
+      uri,
+      attributes: undefined,
+      attributesWithPrefix: undefined,
+      value: undefined,
+      error: undefined,
+    } as unknown as EndElementEvent;
+
+    this.pos = tagClose + 1;
+  }
+
+  private *parseCdataCommentDoctype(): Generator<AnyXmlEvent> {
+    if (this.matchesAt('<![CDATA[', this.pos)) {
+      const cdataEnd = this.findSequence(']]>', this.pos + 9);
+      if (cdataEnd === -1) {
+        throw new Error('Unclosed CDATA section');
+      }
+
+      yield {
+        type: XmlEventType.CDATA,
+        name: undefined,
+        localName: undefined,
+        prefix: undefined,
+        uri: undefined,
+        attributes: undefined,
+        attributesWithPrefix: undefined,
+        value: this.xml.slice(this.pos + 9, cdataEnd),
+        error: undefined,
+      } as unknown as CdataEvent;
+
+      this.pos = cdataEnd + 3;
+      return;
+    }
+
+    if (this.matchesAt('<!--', this.pos)) {
+      const commentEnd = this.findSequence('-->', this.pos + 4);
+      if (commentEnd === -1) {
+        throw new Error('Unclosed comment');
+      }
+      this.pos = commentEnd + 3;
+      return;
+    }
+
+    if (this.matchesAt('<!DOCTYPE', this.pos)) {
+      const doctypeEnd = this.findDoctypeEnd(this.pos + 9);
+      if (doctypeEnd === -1) {
+        throw new Error('Unclosed DOCTYPE declaration');
+      }
+      this.pos = doctypeEnd + 1;
+      return;
+    }
+  }
+
+  private *parseProcessingInstruction(): Generator<AnyXmlEvent> {
+    const piEnd = this.findSequence('?>', this.pos);
+    if (piEnd === -1) {
+      throw new Error('Unclosed processing instruction');
+    }
+    this.pos = piEnd + 2;
+  }
+
+  private *parseStartTag(): Generator<AnyXmlEvent> {
+    const tagStart = this.pos + 1;
+    const tagEnd = this.findTagEnd(tagStart);
+    if (tagEnd === -1) {
+      throw new Error('Unclosed start tag');
+    }
+
+    let isSelfClosing = false;
+    let actualEnd = tagEnd;
+    if (this.xml.charCodeAt(tagEnd - 1) === 47) {
+      isSelfClosing = true;
+      actualEnd = tagEnd - 1;
+    }
+
+    let nameEnd = tagStart;
+    while (nameEnd < actualEnd) {
+      const code = this.xml.charCodeAt(nameEnd);
+      if (code <= 32) {
+        if (StaxXmlParserSync.isWhitespace(code)) break;
+      } else if (code === 62 || code === 47) {
+        break;
+      }
+      nameEnd++;
+    }
+
+    const tagName = this.xml.slice(tagStart, nameEnd);
+    const parentNamespaces = this.namespaceStack.length > 0
+      ? this.namespaceStack[this.namespaceStack.length - 1]
+      : new Map<string, string>();
+    const currentNamespaces = this.hasNamespaceDeclaration(nameEnd, actualEnd)
+      ? new Map<string, string>(parentNamespaces)
+      : parentNamespaces;
+
+    const { attributes, attributesWithPrefix } = this.parseAttributesFast(
+      nameEnd,
+      actualEnd,
+      currentNamespaces
+    );
+
+    const colonIndex = tagName.indexOf(':');
+    let localName: string;
+    let prefix: string | undefined;
+    let uri: string | undefined;
+
+    if (colonIndex === -1) {
+      localName = tagName;
+      prefix = undefined;
+      uri = currentNamespaces.get('');
+    } else {
+      prefix = tagName.slice(0, colonIndex);
+      localName = tagName.slice(colonIndex + 1);
+      uri = currentNamespaces.get(prefix);
+    }
+
+    yield {
+      type: XmlEventType.START_ELEMENT,
+      name: tagName,
+      localName,
+      prefix,
+      uri,
+      attributes,
+      attributesWithPrefix,
+      value: undefined,
+      error: undefined,
+    } as unknown as StartElementEvent;
+
+    this.elementStack.push(tagName);
+
+    if (!isSelfClosing) {
+      this.namespaceStack.push(currentNamespaces);
+    } else {
+      yield {
+        type: XmlEventType.END_ELEMENT,
+        name: tagName,
+        localName,
+        prefix,
+        uri,
+        attributes: undefined,
+        attributesWithPrefix: undefined,
+        value: undefined,
+        error: undefined,
+      } as unknown as EndElementEvent;
+      this.elementStack.pop();
+    }
+
+    this.pos = tagEnd + 1;
+  }
+
+  private parseAttributesFast(
+    start: number,
+    end: number,
+    namespaces: Map<string, string>
+  ): {
+    attributes: Record<string, string>;
+    attributesWithPrefix: Record<string, AttributeInfo>;
+  } {
+    if (start >= end) {
+      return {
+        attributes: {},
+        attributesWithPrefix: {},
+      };
+    }
+
+    const attributes: Record<string, string> = {};
+    const attributesWithPrefix: Record<string, AttributeInfo> = {};
+
+    let index = start;
+    while (index < end) {
+      while (index < end && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(index))) {
+        index++;
+      }
+      if (index >= end) {
+        break;
+      }
+
+      const nameStart = index;
+      while (index < end) {
+        const code = this.xml.charCodeAt(index);
+        if (code === 61 || StaxXmlParserSync.isWhitespace(code)) {
+          break;
+        }
+        index++;
+      }
+
+      if (index === nameStart) {
+        break;
+      }
+      const attrName = this.xml.slice(nameStart, index);
+
+      while (index < end && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(index))) {
+        index++;
+      }
+      if (index >= end || this.xml.charCodeAt(index) !== 61) {
+        attributes[attrName] = 'true';
+
+        const colonIndex = attrName.indexOf(':');
+        let localName: string;
+        let prefix: string | undefined;
+        let uri: string | undefined;
+
+        if (colonIndex === -1) {
+          localName = attrName;
+          prefix = undefined;
+          uri = undefined;
+        } else {
+          prefix = attrName.slice(0, colonIndex);
+          localName = attrName.slice(colonIndex + 1);
+          uri = namespaces.get(prefix);
+        }
+
+        attributesWithPrefix[attrName] = { value: 'true', localName, prefix, uri };
+        continue;
+      }
+
+      index++;
+      while (index < end && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(index))) {
+        index++;
+      }
+      if (index >= end) {
+        break;
+      }
+
+      const quote = this.xml.charCodeAt(index);
+      if (quote !== 34 && quote !== 39) {
+        break;
+      }
+
+      index++;
+      const valueStart = index;
+      while (index < end && this.xml.charCodeAt(index) !== quote) {
+        index++;
+      }
+
+      const attrValue = this.entityDecoder(this.xml.slice(valueStart, index));
+      attributes[attrName] = attrValue;
+
+      if (attrName === 'xmlns') {
+        namespaces.set('', attrValue);
+      } else if (attrName.startsWith('xmlns:')) {
+        namespaces.set(attrName.slice(6), attrValue);
+      }
+
+      const colonIndex = attrName.indexOf(':');
+      let localName: string;
+      let prefix: string | undefined;
+      let uri: string | undefined;
+
+      if (colonIndex === -1) {
+        localName = attrName;
+        prefix = undefined;
+        uri = undefined;
+      } else {
+        prefix = attrName.slice(0, colonIndex);
+        localName = attrName.slice(colonIndex + 1);
+        uri = namespaces.get(prefix);
+      }
+
+      if (attrName.startsWith('xmlns')) {
+        if (attrName === 'xmlns') {
+          localName = 'xmlns';
+          prefix = undefined;
+        } else {
+          localName = attrName.slice(6);
+          prefix = 'xmlns';
+        }
+      }
+
+      attributesWithPrefix[attrName] = {
+        value: attrValue,
+        localName,
+        prefix,
+        uri,
+      };
+
+      index++;
+    }
+
+    return { attributes, attributesWithPrefix };
+  }
+
+  private hasNamespaceDeclaration(start: number, end: number): boolean {
+    let index = start;
+
+    while (index < end) {
+      while (index < end && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(index))) {
+        index++;
+      }
+      if (index >= end) {
+        return false;
+      }
+
+      const nameStart = index;
+      while (index < end) {
+        const code = this.xml.charCodeAt(index);
+        if (code === 61 || StaxXmlParserSync.isWhitespace(code)) {
+          break;
+        }
+        index++;
+      }
+
+      if (index === nameStart) {
+        return false;
+      }
+
+      const attrName = this.xml.slice(nameStart, index);
+      if (attrName === 'xmlns' || attrName.startsWith('xmlns:')) {
+        return true;
+      }
+
+      while (index < end && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(index))) {
+        index++;
+      }
+      if (index >= end || this.xml.charCodeAt(index) !== 61) {
+        continue;
+      }
+
+      index++;
+      while (index < end && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(index))) {
+        index++;
+      }
+      if (index >= end) {
+        return false;
+      }
+
+      const quote = this.xml.charCodeAt(index);
+      if (quote !== 34 && quote !== 39) {
+        return false;
+      }
+
+      index++;
+      while (index < end && this.xml.charCodeAt(index) !== quote) {
+        index++;
+      }
+      if (index < end) {
+        index++;
+      }
+    }
+
+    return false;
+  }
+
+  private findTagEnd(start: number): number {
+    let index = start;
+    let inQuote = false;
+    let quoteChar = 0;
+
+    while (index < this.xmlLength) {
+      const code = this.xml.charCodeAt(index);
+      if (code === 34 || code === 39) {
+        if (!inQuote) {
+          inQuote = true;
+          quoteChar = code;
+        } else if (code === quoteChar) {
+          inQuote = false;
+          quoteChar = 0;
+        }
+      } else if (code === 62 && !inQuote) {
+        return index;
+      }
+      index++;
+    }
+
+    return -1;
+  }
+
+  private findSequence(sequence: string, start: number): number {
+    const sequenceLength = sequence.length;
+    const maxPos = this.xmlLength - sequenceLength;
+
+    for (let index = start; index <= maxPos; index++) {
+      let matches = true;
+      for (let offset = 0; offset < sequenceLength; offset++) {
+        if (this.xml.charCodeAt(index + offset) !== sequence.charCodeAt(offset)) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches) {
+        return index;
+      }
+    }
+
+    return -1;
+  }
+
+  private findDoctypeEnd(start: number): number {
+    let position = start;
+    let bracketDepth = 0;
+    let quoteChar = 0;
+    let inComment = false;
+
+    while (position < this.xmlLength) {
+      const currentChar = this.xml.charCodeAt(position);
+
+      if (inComment) {
+        if (this.matchesAt('-->', position)) {
+          inComment = false;
+          position += 3;
+          continue;
+        }
+        position++;
+        continue;
+      }
+
+      if (quoteChar !== 0) {
+        if (currentChar === quoteChar) {
+          quoteChar = 0;
+        }
+        position++;
+        continue;
+      }
+
+      if (currentChar === 34 || currentChar === 39) {
+        quoteChar = currentChar;
+        position++;
+        continue;
+      }
+
+      if (this.matchesAt('<!--', position)) {
+        inComment = true;
+        position += 4;
+        continue;
+      }
+
+      if (currentChar === 91) {
+        bracketDepth++;
+        position++;
+        continue;
+      }
+
+      if (currentChar === 93) {
+        if (bracketDepth > 0) {
+          bracketDepth--;
+        }
+        position++;
+        continue;
+      }
+
+      if (currentChar === 62 && bracketDepth === 0) {
+        return position;
+      }
+
+      position++;
+    }
+
+    return -1;
+  }
+
+  private findChar(targetCode: number, start: number = this.pos): number {
+    const len16 = this.xmlLength - 15;
+    let index = start;
+
+    for (; index < len16; index += 16) {
+      if (this.xml.charCodeAt(index) === targetCode) return index;
+      if (this.xml.charCodeAt(index + 1) === targetCode) return index + 1;
+      if (this.xml.charCodeAt(index + 2) === targetCode) return index + 2;
+      if (this.xml.charCodeAt(index + 3) === targetCode) return index + 3;
+      if (this.xml.charCodeAt(index + 4) === targetCode) return index + 4;
+      if (this.xml.charCodeAt(index + 5) === targetCode) return index + 5;
+      if (this.xml.charCodeAt(index + 6) === targetCode) return index + 6;
+      if (this.xml.charCodeAt(index + 7) === targetCode) return index + 7;
+      if (this.xml.charCodeAt(index + 8) === targetCode) return index + 8;
+      if (this.xml.charCodeAt(index + 9) === targetCode) return index + 9;
+      if (this.xml.charCodeAt(index + 10) === targetCode) return index + 10;
+      if (this.xml.charCodeAt(index + 11) === targetCode) return index + 11;
+      if (this.xml.charCodeAt(index + 12) === targetCode) return index + 12;
+      if (this.xml.charCodeAt(index + 13) === targetCode) return index + 13;
+      if (this.xml.charCodeAt(index + 14) === targetCode) return index + 14;
+      if (this.xml.charCodeAt(index + 15) === targetCode) return index + 15;
+    }
+
+    for (; index < this.xmlLength; index++) {
+      if (this.xml.charCodeAt(index) === targetCode) {
+        return index;
+      }
+    }
+
+    return -1;
+  }
+
+  private matchesAt(value: string, pos: number): boolean {
+    const length = value.length;
+    if (pos + length > this.xmlLength) {
+      return false;
+    }
+
+    for (let index = 0; index < length; index++) {
+      if (this.xml.charCodeAt(pos + index) !== value.charCodeAt(index)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private trimmedSlice(start: number, end: number): string {
+    while (start < end && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(start))) {
+      if (StaxXmlParserSync.isHighSurrogate(this.xml.charCodeAt(start))) {
+        start += 2;
+      } else {
+        start++;
+      }
+    }
+
+    while (end > start && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(end - 1))) {
+      if (
+        end > start + 1 &&
+        StaxXmlParserSync.isLowSurrogate(this.xml.charCodeAt(end - 1)) &&
+        StaxXmlParserSync.isHighSurrogate(this.xml.charCodeAt(end - 2))
+      ) {
+        end -= 2;
+      } else {
+        end--;
+      }
+    }
+
+    return start < end ? this.xml.slice(start, end) : '';
+  }
+
+  private compileEntityDecoder(): (text: string) => string {
+    if (!this.options.autoDecodeEntities) {
+      return (text) => text;
+    }
+
+    if (this.options.addEntities && this.options.addEntities.length > 0) {
+      const entityMap: Record<string, string> = { ...StaxXmlParserSync.DEFAULT_ENTITY_MAP };
+      const patterns: string[] = ['lt', 'gt', 'quot', 'apos'];
+
+      for (const { entity, value } of this.options.addEntities) {
+        if (entity && value) {
+          const key = entity.startsWith('&') && entity.endsWith(';')
+            ? entity.slice(1, -1)
+            : entity;
+          entityMap[key] = value;
+          patterns.push(key);
+        }
+      }
+      patterns.push('amp');
+
+      const cacheKey = patterns.join(',');
+      let regex = StaxXmlParserSync.ENTITY_REGEX_CACHE.get(cacheKey);
+      if (!regex) {
+        const pattern = patterns
+          .sort((left, right) => right.length - left.length)
+          .map((entity) => entity.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+          .join('|');
+        regex = new RegExp(`&(${pattern});`, 'g');
+        StaxXmlParserSync.ENTITY_REGEX_CACHE.set(cacheKey, regex);
+      }
+
+      return (text: string) => {
+        if (!text || text.indexOf('&') === -1) {
+          return text;
+        }
+        regex!.lastIndex = 0;
+        return text.replace(regex!, (_, entity) => entityMap[entity] || _);
+      };
+    }
+
+    return (text: string) => {
+      if (!text || text.indexOf('&') === -1) {
+        return text;
+      }
+      StaxXmlParserSync.DEFAULT_ENTITY_REGEX.lastIndex = 0;
+      return text.replace(
+        StaxXmlParserSync.DEFAULT_ENTITY_REGEX,
+        (_, entity) => StaxXmlParserSync.DEFAULT_ENTITY_MAP[entity] || _
+      );
+    };
+  }
+
+  private static isWhitespace(code: number): boolean {
+    if (code < 128) {
+      return StaxXmlParserSync.ASCII_TABLE[code] === 1;
+    }
+    return code <= 32 || StaxXmlParserSync.UNICODE_WHITESPACE.has(code);
+  }
+
+  private static isHighSurrogate(code: number): boolean {
+    return code >= 0xD800 && code <= 0xDBFF;
+  }
+
+  private static isLowSurrogate(code: number): boolean {
+    return code >= 0xDC00 && code <= 0xDFFF;
   }
 }
 

--- a/packages/stax-xml/src/StaxXmlParserSync.ts
+++ b/packages/stax-xml/src/StaxXmlParserSync.ts
@@ -1,712 +1,88 @@
-// StaxXmlParserSync.ts - Optimized version using XmlEventFactory
-
 import {
-  AnyXmlEvent,
-  AttributeInfo,
-  CdataEvent,
-  CharactersEvent,
-  EndDocumentEvent,
-  EndElementEvent,
-  StartElementEvent,
-  XmlEventType
+  type AnyXmlEvent,
+  type EndDocumentEvent,
+  type EndElementEvent,
+  type ErrorEvent,
+  type StartDocumentEvent,
+  type StartElementEvent,
+  XmlEventFactory,
+  XmlEventType,
 } from './types';
+import {
+  StaxXmlCursorSync,
+  type StaxXmlCursorSyncOptions,
+} from './StaxXmlCursorSync';
 
-export interface StaxXmlParserSyncOptions {
-  autoDecodeEntities?: boolean;
-  addEntities?: { entity: string, value: string }[];
-}
+export type { StaxXmlCursorSyncOptions };
 
 export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXmlEvent> {
-  private readonly xml: string;
-  private readonly xmlLength: number;
-  private pos: number = 0;
-  private readonly elementStack: string[] = [];
-  private namespaceStack: Map<string, string>[] = [];
-  private readonly options: StaxXmlParserSyncOptions;
-  private internalIterator?: Generator<AnyXmlEvent>;
+  private readonly cursor: StaxXmlCursorSync;
+  private done = false;
 
-  // ===== Static optimization tables and caches =====
-
-  // ASCII character fast classification table (0-127)
-  private static readonly ASCII_TABLE = (() => {
-    const table = new Uint8Array(128);
-    // Whitespace characters: 1
-    table[9] = 1;   // TAB
-    table[10] = 1;  // LF
-    table[13] = 1;  // CR
-    table[32] = 1;  // SPACE
-    // XML special characters
-    table[60] = 2;  // '<'
-    table[62] = 3;  // '>'
-    table[47] = 4;  // '/'
-    table[61] = 5;  // '='
-    table[33] = 6;  // '!'
-    table[63] = 7;  // '?'
-    table[34] = 8;  // '"'
-    table[39] = 9;  // "'"
-    return table;
-  })();
-
-  // Multilingual whitespace character Set (fast lookup)
-  private static readonly UNICODE_WHITESPACE = new Set([
-    0x00A0, // Non-breaking space
-    0x1680, // Ogham space
-    0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007, 0x2008, 0x2009, 0x200A, // Various spaces
-    0x2028, // Line separator
-    0x2029, // Paragraph separator
-    0x202F, // Narrow no-break space
-    0x205F, // Medium mathematical space
-    0x3000, // CJK ideographic space
-    0xFEFF  // Zero-width no-break space
-  ]);
-
-  // Entity regex cache
-  private static readonly ENTITY_REGEX_CACHE = new Map<string, RegExp>();
-  private static readonly DEFAULT_ENTITY_REGEX = /&(lt|gt|quot|apos|amp);/g;
-  private static readonly DEFAULT_ENTITY_MAP: Record<string, string> = {
-    'lt': '<', 'gt': '>', 'quot': '"', 'apos': "'", 'amp': '&'
-  };
-
-  // Compiled entity decoder (per-instance caching)
-  private readonly entityDecoder: (text: string) => string;
-
-  constructor(xml: string, options: StaxXmlParserSyncOptions = {}) {
-    this.xml = xml;
-    this.xmlLength = xml.length;
-    this.options = {
-      autoDecodeEntities: true,
-      ...options
-    };
-
-    this.namespaceStack.push(new Map<string, string>());
-
-    // Pre-compile entity decoder
-    this.entityDecoder = this.compileEntityDecoder();
+  constructor(xml: string, options: StaxXmlCursorSyncOptions = {}) {
+    this.cursor = new StaxXmlCursorSync(xml, options);
   }
 
-  // ===== Helper methods: character classification =====
-
-  private static isWhitespace(code: number): boolean {
-    if (code < 128) {
-      return StaxXmlParserSync.ASCII_TABLE[code] === 1;
-    }
-    return code <= 32 || StaxXmlParserSync.UNICODE_WHITESPACE.has(code);
-  }
-
-  // ===== Helper methods: surrogate pair handling =====
-
-  private static isHighSurrogate(code: number): boolean {
-    return code >= 0xD800 && code <= 0xDBFF;
-  }
-
-  private static isLowSurrogate(code: number): boolean {
-    return code >= 0xDC00 && code <= 0xDFFF;
-  }
-
-  // ===== Optimized string processing =====
-
-  // indexOf replacement - fast character search (16-byte unrolling)
-  private findChar(targetCode: number, start: number = this.pos): number {
-    const xml = this.xml;
-    const len = this.xmlLength;
-
-    // Performance improvement with 16-byte unrolling
-    const len16 = len - 15;
-    let i = start;
-
-    // 16-byte unrolling loop
-    for (; i < len16; i += 16) {
-      if (xml.charCodeAt(i) === targetCode) return i;
-      if (xml.charCodeAt(i + 1) === targetCode) return i + 1;
-      if (xml.charCodeAt(i + 2) === targetCode) return i + 2;
-      if (xml.charCodeAt(i + 3) === targetCode) return i + 3;
-      if (xml.charCodeAt(i + 4) === targetCode) return i + 4;
-      if (xml.charCodeAt(i + 5) === targetCode) return i + 5;
-      if (xml.charCodeAt(i + 6) === targetCode) return i + 6;
-      if (xml.charCodeAt(i + 7) === targetCode) return i + 7;
-      if (xml.charCodeAt(i + 8) === targetCode) return i + 8;
-      if (xml.charCodeAt(i + 9) === targetCode) return i + 9;
-      if (xml.charCodeAt(i + 10) === targetCode) return i + 10;
-      if (xml.charCodeAt(i + 11) === targetCode) return i + 11;
-      if (xml.charCodeAt(i + 12) === targetCode) return i + 12;
-      if (xml.charCodeAt(i + 13) === targetCode) return i + 13;
-      if (xml.charCodeAt(i + 14) === targetCode) return i + 14;
-      if (xml.charCodeAt(i + 15) === targetCode) return i + 15;
-    }
-
-    // Handle remaining bytes
-    for (; i < len; i++) {
-      if (xml.charCodeAt(i) === targetCode) return i;
-    }
-
-    return -1;
-  }
-
-  // Fast string search (startsWith replacement)
-  private matchesAt(str: string, pos: number): boolean {
-    const len = str.length;
-    if (pos + len > this.xmlLength) return false;
-
-    for (let i = 0; i < len; i++) {
-      if (this.xml.charCodeAt(pos + i) !== str.charCodeAt(i)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  // Inline trim (avoid substring)
-  private trimmedSlice(start: number, end: number): string {
-    const xml = this.xml;
-
-    // Remove leading whitespace
-    while (start < end && StaxXmlParserSync.isWhitespace(xml.charCodeAt(start))) {
-      if (StaxXmlParserSync.isHighSurrogate(xml.charCodeAt(start))) {
-        start += 2;
-      } else {
-        start++;
-      }
-    }
-
-    // Remove trailing whitespace
-    while (end > start && StaxXmlParserSync.isWhitespace(xml.charCodeAt(end - 1))) {
-      // Surrogate pair check (reverse direction)
-      if (end > start + 1 &&
-        StaxXmlParserSync.isLowSurrogate(xml.charCodeAt(end - 1)) &&
-        StaxXmlParserSync.isHighSurrogate(xml.charCodeAt(end - 2))) {
-        end -= 2;
-      } else {
-        end--;
-      }
-    }
-
-    return start < end ? xml.slice(start, end) : '';
-  }
-
-  // ===== Entity processing optimization =====
-
-  private compileEntityDecoder(): (text: string) => string {
-    if (!this.options.autoDecodeEntities) {
-      return (text) => text;
-    }
-
-    // If custom entities exist
-    if (this.options.addEntities && this.options.addEntities.length > 0) {
-      const entityMap: Record<string, string> = { ...StaxXmlParserSync.DEFAULT_ENTITY_MAP };
-      const patterns: string[] = ['lt', 'gt', 'quot', 'apos'];
-
-      for (const { entity, value } of this.options.addEntities) {
-        if (entity && value) {
-          // Extract only entity part from &entity; format
-          const key = entity.startsWith('&') && entity.endsWith(';')
-            ? entity.slice(1, -1)
-            : entity;
-          entityMap[key] = value;
-          patterns.push(key);
-        }
-      }
-      patterns.push('amp'); // amp goes last
-
-      // Generate cache key and regex caching
-      const cacheKey = patterns.join(',');
-      let regex = StaxXmlParserSync.ENTITY_REGEX_CACHE.get(cacheKey);
-
-      if (!regex) {
-        const pattern = patterns
-          .sort((a, b) => b.length - a.length) // Longer patterns first
-          .map(e => e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-          .join('|');
-        regex = new RegExp(`&(${pattern});`, 'g');
-        StaxXmlParserSync.ENTITY_REGEX_CACHE.set(cacheKey, regex);
-      }
-
-      return (text: string) => {
-        if (!text || text.indexOf('&') === -1) return text;
-        regex!.lastIndex = 0;
-        return text.replace(regex!, (_, entity) => entityMap[entity] || _);
-      };
-    }
-
-    // Use only default entities
-    return (text: string) => {
-      if (!text || text.indexOf('&') === -1) return text;
-      StaxXmlParserSync.DEFAULT_ENTITY_REGEX.lastIndex = 0;
-      return text.replace(
-        StaxXmlParserSync.DEFAULT_ENTITY_REGEX,
-        (_, entity) => StaxXmlParserSync.DEFAULT_ENTITY_MAP[entity] || _
-      );
-    };
-  }
-
-  // ===== Main parsing logic - using EventFactory =====
-
-  /**
-   * Symbol.iterator implementation - returns this instance as iterator
-   * This ensures for...of and explicit next() calls use the same iterator state
-   */
   public [Symbol.iterator](): Iterator<AnyXmlEvent> {
     return this;
   }
 
-  /**
-   * Internal generator that actually yields AnyXmlEvent
-   * Important: Return type is same as before - Iterator<AnyXmlEvent>
-   * Factory internally creates UnifiedXmlEvent, but
-   * types are returned as StartElementEvent, EndElementEvent etc. so
-   * perfectly compatible with AnyXmlEvent union type
-   */
-  private *internalGenerator(): Generator<AnyXmlEvent> {
-    // Inline startDocument() - maintains V8 hidden class optimization
-    // All events have same shape with undefined for unused fields
-    yield {
-      type: XmlEventType.START_DOCUMENT,
-      name: undefined,
-      localName: undefined,
-      prefix: undefined,
-      uri: undefined,
-      attributes: undefined,
-      attributesWithPrefix: undefined,
-      value: undefined,
-      error: undefined
-    } as unknown as StartElementEvent;
-
-    while (this.pos < this.xmlLength) {
-      const ltPos = this.findChar(60, this.pos); // Find '<'
-
-      if (ltPos === -1) {
-        // Process remaining text
-        if (this.pos < this.xmlLength) {
-          const text = this.trimmedSlice(this.pos, this.xmlLength);
-          if (text) {
-            // Inline characters() - maintains V8 hidden class optimization
-            yield {
-              type: XmlEventType.CHARACTERS,
-              name: undefined,
-              localName: undefined,
-              prefix: undefined,
-              uri: undefined,
-              attributes: undefined,
-              attributesWithPrefix: undefined,
-              value: this.entityDecoder(text),
-              error: undefined
-            } as unknown as CharactersEvent;
-          }
-        }
-        break;
-      }
-
-      // Process text before '<'
-      if (ltPos > this.pos) {
-        const text = this.trimmedSlice(this.pos, ltPos);
-        if (text) {
-          // Inline characters() - maintains V8 hidden class optimization
-          yield {
-            type: XmlEventType.CHARACTERS,
-            name: undefined,
-            localName: undefined,
-            prefix: undefined,
-            uri: undefined,
-            attributes: undefined,
-            attributesWithPrefix: undefined,
-            value: this.entityDecoder(text),
-            error: undefined
-          } as unknown as CharactersEvent;
-        }
-      }
-
-      this.pos = ltPos;
-      const nextCharCode = this.xml.charCodeAt(this.pos + 1);
-
-      switch (nextCharCode) {
-        case 47: // '/'
-          yield* this.parseEndTag();
-          break;
-        case 33: // '!'
-          yield* this.parseCdataCommentDoctype();
-          break;
-        case 63: // '?'
-          yield* this.parseProcessingInstruction();
-          break;
-        default:
-          yield* this.parseStartTag();
-          break;
-      }
-    }
-
-    // Inline endDocument() - maintains V8 hidden class optimization
-    yield {
-      type: XmlEventType.END_DOCUMENT,
-      name: undefined,
-      localName: undefined,
-      prefix: undefined,
-      uri: undefined,
-      attributes: undefined,
-      attributesWithPrefix: undefined,
-      value: undefined,
-      error: undefined
-    } as unknown as EndDocumentEvent;
-  }
-
   public next(): IteratorResult<AnyXmlEvent> {
-    if (!this.internalIterator) {
-      this.internalIterator = this.internalGenerator();
-    }
-    return this.internalIterator.next();
-  }
-
-  // ===== Tag parsing methods - using EventFactory =====
-
-  private *parseEndTag(): Generator<AnyXmlEvent> {
-    const tagClose = this.findChar(62, this.pos); // '>'
-    if (tagClose === -1) throw new Error('Unclosed end tag');
-
-    const fullTagName = this.trimmedSlice(this.pos + 2, tagClose);
-
-    if (this.elementStack.length === 0) {
-      throw new Error(`Mismatched closing tag: </${fullTagName}>. No open elements.`);
+    if (this.done) {
+      return { value: undefined, done: true };
     }
 
-    const expectedTagName = this.elementStack[this.elementStack.length - 1];
-    if (fullTagName !== expectedTagName) {
-      throw new Error(`Mismatched closing tag: </${fullTagName}>. Expected </${expectedTagName}>.`);
-    }
-
-    this.elementStack.pop();
-    const currentNamespaces = this.namespaceStack.pop();
-
-    // Inline QName parsing (for end tag) - optimized
-    const colonIndex = fullTagName.indexOf(':');
-    let localName: string, prefix: string | undefined, uri: string | undefined;
-
-    if (colonIndex === -1) {
-      localName = fullTagName;
-      prefix = undefined;
-      uri = currentNamespaces ? currentNamespaces.get('') : undefined;
-    } else {
-      prefix = fullTagName.slice(0, colonIndex);
-      localName = fullTagName.slice(colonIndex + 1);
-      uri = currentNamespaces ? currentNamespaces.get(prefix) : undefined;
-    }
-
-    // Inline endElement() - maintains V8 hidden class optimization
-    yield {
-      type: XmlEventType.END_ELEMENT,
-      name: fullTagName,
-      localName,
-      prefix,
-      uri,
-      attributes: undefined,
-      attributesWithPrefix: undefined,
-      value: undefined,
-      error: undefined
-    } as unknown as EndElementEvent;
-
-    this.pos = tagClose + 1;
-  }
-
-  private *parseCdataCommentDoctype(): Generator<AnyXmlEvent> {
-    if (this.matchesAt('<![CDATA[', this.pos)) {
-      const cdataEnd = this.findSequence(']]>', this.pos + 9);
-      if (cdataEnd === -1) throw new Error('Unclosed CDATA section');
-
-      const cdataContent = this.xml.slice(this.pos + 9, cdataEnd);
-      // Inline cdata() - maintains V8 hidden class optimization
-      yield {
-        type: XmlEventType.CDATA,
-        name: undefined,
-        localName: undefined,
-        prefix: undefined,
-        uri: undefined,
-        attributes: undefined,
-        attributesWithPrefix: undefined,
-        value: cdataContent,
-        error: undefined
-      } as unknown as CdataEvent;
-
-      this.pos = cdataEnd + 3;
-    } else if (this.matchesAt('<!--', this.pos)) {
-      const commentEnd = this.findSequence('-->', this.pos + 4);
-      if (commentEnd === -1) throw new Error('Unclosed comment');
-      this.pos = commentEnd + 3;
-    } else if (this.matchesAt('<!DOCTYPE', this.pos)) {
-      const doctypeEnd = this.findChar(62, this.pos); // '>'
-      if (doctypeEnd === -1) throw new Error('Unclosed DOCTYPE declaration');
-      this.pos = doctypeEnd + 1;
-    }
-  }
-
-  private *parseProcessingInstruction(): Generator<AnyXmlEvent> {
-    const piEnd = this.findSequence('?>', this.pos);
-    if (piEnd === -1) throw new Error('Unclosed processing instruction');
-    this.pos = piEnd + 2;
-  }
-
-  private *parseStartTag(): Generator<AnyXmlEvent> {
-    const tagStart = this.pos + 1;
-    const tagEnd = this.findTagEnd(tagStart);
-    if (tagEnd === -1) throw new Error('Unclosed start tag');
-
-    let isSelfClosing = false;
-    let actualEnd = tagEnd;
-
-    if (this.xml.charCodeAt(tagEnd - 1) === 47) { // '/'
-      isSelfClosing = true;
-      actualEnd = tagEnd - 1;
-    }
-
-    // Separate tag name and attributes (optimized)
-    let nameEnd = tagStart;
-    const xml = this.xml;
-
-    // Fast tag name search (find whitespace, '>', '/')
-    while (nameEnd < actualEnd) {
-      const code = xml.charCodeAt(nameEnd);
-      // Fast branching for ASCII range
-      if (code <= 32) {
-        if (StaxXmlParserSync.isWhitespace(code)) break;
-      } else if (code === 62 || code === 47) { // '>' or '/'
-        break;
+    try {
+      const tokenType = this.cursor.next();
+      const event = this.materializeEvent(tokenType);
+      if (tokenType === XmlEventType.END_DOCUMENT) {
+        this.done = true;
       }
-      nameEnd++;
-    }
-
-    const tagName = xml.slice(tagStart, nameEnd);
-
-    // Create namespace context
-    const currentNamespaces = new Map<string, string>();
-    if (this.namespaceStack.length > 0) {
-      const parentNamespaces = this.namespaceStack[this.namespaceStack.length - 1];
-      for (const [prefix, uri] of parentNamespaces) {
-        currentNamespaces.set(prefix, uri);
-      }
-    }
-
-    // Attribute parsing (inline optimization)
-    const { attributes, attributesWithPrefix } = this.parseAttributesFast(
-      nameEnd,
-      actualEnd,
-      currentNamespaces
-    );
-
-    // Inline QName parsing (for tag name) - optimized
-    const colonIndex = tagName.indexOf(':');
-    let localName: string, prefix: string | undefined, uri: string | undefined;
-
-    if (colonIndex === -1) {
-      localName = tagName;
-      prefix = undefined;
-      uri = currentNamespaces.get('');
-    } else {
-      prefix = tagName.slice(0, colonIndex);
-      localName = tagName.slice(colonIndex + 1);
-      uri = currentNamespaces.get(prefix);
-    }
-
-    // Inline startElement() - maintains V8 hidden class optimization
-    yield {
-      type: XmlEventType.START_ELEMENT,
-      name: tagName,
-      localName,
-      prefix,
-      uri,
-      attributes,
-      attributesWithPrefix,
-      value: undefined,
-      error: undefined
-    } as unknown as StartElementEvent;
-
-    this.elementStack.push(tagName);
-
-    if (!isSelfClosing) {
-      this.namespaceStack.push(currentNamespaces);
-    } else {
-      // Inline endElement() for self-closing tags - maintains V8 hidden class optimization
-      yield {
-        type: XmlEventType.END_ELEMENT,
-        name: tagName,
-        localName,
-        prefix,
-        uri,
-        attributes: undefined,
-        attributesWithPrefix: undefined,
-        value: undefined,
-        error: undefined
-      } as unknown as EndElementEvent;
-      this.elementStack.pop();
-    }
-
-    this.pos = tagEnd + 1;
-  }
-
-  // ===== Attribute parsing (optimized) =====
-
-  private parseAttributesFast(
-    start: number,
-    end: number,
-    namespaces: Map<string, string>
-  ): {
-    attributes: Record<string, string>,
-    attributesWithPrefix: Record<string, AttributeInfo>
-  } {
-    // Fast path: when there are no attributes
-    if (start >= end) {
       return {
-        attributes: {},
-        attributesWithPrefix: {}
+        value: event,
+        done: false,
+      };
+    } catch (error) {
+      this.done = true;
+      return {
+        value: XmlEventFactory.error(error as Error) as ErrorEvent,
+        done: false,
       };
     }
-
-    const attributes: Record<string, string> = {};
-    const attributesWithPrefix: Record<string, AttributeInfo> = {};
-
-    let i = start;
-    const xml = this.xml;
-
-    while (i < end) {
-      // Skip whitespace (handled inline)
-      while (i < end && StaxXmlParserSync.isWhitespace(xml.charCodeAt(i))) i++;
-      if (i >= end) break;
-
-      // Extract attribute name
-      const nameStart = i;
-      while (i < end) {
-        const code = xml.charCodeAt(i);
-        if (code === 61 || StaxXmlParserSync.isWhitespace(code)) break; // '=' or space
-        i++;
-      }
-
-      if (i === nameStart) break;
-      const attrName = xml.slice(nameStart, i);
-
-      // Find '='
-      while (i < end && StaxXmlParserSync.isWhitespace(xml.charCodeAt(i))) i++;
-      if (i >= end || xml.charCodeAt(i) !== 61) {
-        // Boolean attribute - parseQualifiedName inline processing
-        attributes[attrName] = 'true';
-
-        // Inline QName parsing (for attributes)
-        const colonIndex = attrName.indexOf(':');
-        let localName: string, prefix: string | undefined, uri: string | undefined;
-
-        if (colonIndex === -1) {
-          localName = attrName;
-          prefix = undefined;
-          uri = undefined;
-        } else {
-          prefix = attrName.slice(0, colonIndex);
-          localName = attrName.slice(colonIndex + 1);
-          uri = namespaces.get(prefix);
-        }
-
-        attributesWithPrefix[attrName] = { value: 'true', localName, prefix, uri };
-        continue;
-      }
-
-      i++; // Skip '='
-
-      // Find quotes
-      while (i < end && StaxXmlParserSync.isWhitespace(xml.charCodeAt(i))) i++;
-      if (i >= end) break;
-
-      const quote = xml.charCodeAt(i);
-      if (quote !== 34 && quote !== 39) break; // '"' or "'"
-
-      i++;
-      const valueStart = i;
-
-      // Find end of value
-      while (i < end && xml.charCodeAt(i) !== quote) i++;
-
-      const rawValue = xml.slice(valueStart, i);
-      const attrValue = this.entityDecoder(rawValue);
-      attributes[attrName] = attrValue;
-
-      // Handle xmlns
-      if (attrName === 'xmlns') {
-        namespaces.set('', attrValue);
-      } else if (attrName.startsWith('xmlns:')) {
-        namespaces.set(attrName.slice(6), attrValue);
-      }
-
-      // Inline QName parsing (for attributes) - optimized
-      const colonIndex = attrName.indexOf(':');
-      let localName: string, prefix: string | undefined, uri: string | undefined;
-
-      if (colonIndex === -1) {
-        localName = attrName;
-        prefix = undefined;
-        uri = undefined;
-      } else {
-        prefix = attrName.slice(0, colonIndex);
-        localName = attrName.slice(colonIndex + 1);
-        uri = namespaces.get(prefix);
-      }
-
-      // Special handling for xmlns attributes
-      if (attrName.startsWith('xmlns')) {
-        if (attrName === 'xmlns') {
-          localName = 'xmlns';
-          prefix = undefined;
-        } else {
-          localName = attrName.slice(6);
-          prefix = 'xmlns';
-        }
-      }
-
-      attributesWithPrefix[attrName] = {
-        value: attrValue,
-        localName,
-        prefix,
-        uri
-      };
-
-      i++; // Skip closing quote
-    }
-
-    return { attributes, attributesWithPrefix };
   }
 
-  // ===== Utility methods =====
-
-  private findTagEnd(start: number): number {
-    let i = start;
-    let inQuote = false;
-    let quoteChar = 0;
-
-    while (i < this.xmlLength) {
-      const code = this.xml.charCodeAt(i);
-
-      if (code === 34 || code === 39) { // '"' or "'"
-        if (!inQuote) {
-          inQuote = true;
-          quoteChar = code;
-        } else if (code === quoteChar) {
-          inQuote = false;
-          quoteChar = 0;
-        }
-      } else if (code === 62 && !inQuote) { // '>'
-        return i;
-      }
-      i++;
+  private materializeEvent(tokenType: XmlEventType): AnyXmlEvent {
+    switch (tokenType) {
+      case XmlEventType.START_DOCUMENT:
+        return XmlEventFactory.startDocument() as StartDocumentEvent;
+      case XmlEventType.END_DOCUMENT:
+        return XmlEventFactory.endDocument() as EndDocumentEvent;
+      case XmlEventType.START_ELEMENT:
+        return XmlEventFactory.startElement(
+          this.cursor.name,
+          this.cursor.localName,
+          this.cursor.prefix,
+          this.cursor.uri,
+          this.cursor.getAttributes(),
+          this.cursor.getAttributesWithPrefix()
+        ) as StartElementEvent;
+      case XmlEventType.END_ELEMENT:
+        return XmlEventFactory.endElement(
+          this.cursor.name,
+          this.cursor.localName,
+          this.cursor.prefix,
+          this.cursor.uri
+        ) as EndElementEvent;
+      case XmlEventType.CHARACTERS:
+        return XmlEventFactory.characters(this.cursor.getText());
+      case XmlEventType.CDATA:
+        return XmlEventFactory.cdata(this.cursor.getText());
+      case XmlEventType.ERROR:
+        return XmlEventFactory.error(new Error('Cursor should not emit ERROR tokens.'));
+      default:
+        throw new Error(`Unsupported token type: ${String(tokenType)}`);
     }
-    return -1;
   }
-
-  private findSequence(sequence: string, start: number): number {
-    const seqLen = sequence.length;
-    const maxPos = this.xmlLength - seqLen;
-
-    for (let i = start; i <= maxPos; i++) {
-      let match = true;
-      for (let j = 0; j < seqLen; j++) {
-        if (this.xml.charCodeAt(i + j) !== sequence.charCodeAt(j)) {
-          match = false;
-          break;
-        }
-      }
-      if (match) return i;
-    }
-    return -1;
-  }
-
 }
+
+export default StaxXmlParserSync;

--- a/packages/stax-xml/src/StaxXmlParserSync.ts
+++ b/packages/stax-xml/src/StaxXmlParserSync.ts
@@ -22,7 +22,6 @@ export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXml
   private namespaceStack: Map<string, string>[] = [];
   private readonly options: StaxXmlParserSyncOptions;
   private internalIterator?: Generator<AnyXmlEvent>;
-  private done = false;
 
   private static readonly ASCII_TABLE = (() => {
     const table = new Uint8Array(128);
@@ -82,37 +81,11 @@ export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXml
   }
 
   public next(): IteratorResult<AnyXmlEvent> {
-    if (this.done) {
-      return { value: undefined, done: true };
-    }
-
     if (!this.internalIterator) {
       this.internalIterator = this.internalGenerator();
     }
 
-    try {
-      const result = this.internalIterator.next();
-      if (result.done) {
-        this.done = true;
-      }
-      return result;
-    } catch (error) {
-      this.done = true;
-      return {
-        value: {
-          type: XmlEventType.ERROR,
-          name: undefined,
-          localName: undefined,
-          prefix: undefined,
-          uri: undefined,
-          attributes: undefined,
-          attributesWithPrefix: undefined,
-          value: undefined,
-          error: error as Error,
-        } as unknown as AnyXmlEvent,
-        done: false,
-      };
-    }
+    return this.consumeIterator(this.internalIterator);
   }
 
   private *internalGenerator(): Generator<AnyXmlEvent> {
@@ -315,8 +288,9 @@ export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXml
     }
 
     let nameEnd = tagStart;
+    const xml = this.xml;
     while (nameEnd < actualEnd) {
-      const code = this.xml.charCodeAt(nameEnd);
+      const code = xml.charCodeAt(nameEnd);
       if (code <= 32) {
         if (StaxXmlParserSync.isWhitespace(code)) break;
       } else if (code === 62 || code === 47) {
@@ -325,18 +299,13 @@ export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXml
       nameEnd++;
     }
 
-    const tagName = this.xml.slice(tagStart, nameEnd);
-    const parentNamespaces = this.namespaceStack.length > 0
-      ? this.namespaceStack[this.namespaceStack.length - 1]
-      : new Map<string, string>();
-    const currentNamespaces = this.hasNamespaceDeclaration(nameEnd, actualEnd)
-      ? new Map<string, string>(parentNamespaces)
-      : parentNamespaces;
+    const tagName = xml.slice(tagStart, nameEnd);
+    const parentNamespaces = this.namespaceStack[this.namespaceStack.length - 1] ?? new Map<string, string>();
 
-    const { attributes, attributesWithPrefix } = this.parseAttributesFast(
+    const { attributes, attributesWithPrefix, namespaces } = this.parseAttributesFast(
       nameEnd,
       actualEnd,
-      currentNamespaces
+      parentNamespaces
     );
 
     const colonIndex = tagName.indexOf(':');
@@ -347,11 +316,11 @@ export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXml
     if (colonIndex === -1) {
       localName = tagName;
       prefix = undefined;
-      uri = currentNamespaces.get('');
+      uri = namespaces.get('');
     } else {
       prefix = tagName.slice(0, colonIndex);
       localName = tagName.slice(colonIndex + 1);
-      uri = currentNamespaces.get(prefix);
+      uri = namespaces.get(prefix);
     }
 
     yield {
@@ -369,7 +338,7 @@ export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXml
     this.elementStack.push(tagName);
 
     if (!isSelfClosing) {
-      this.namespaceStack.push(currentNamespaces);
+      this.namespaceStack.push(namespaces);
     } else {
       yield {
         type: XmlEventType.END_ELEMENT,
@@ -391,24 +360,29 @@ export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXml
   private parseAttributesFast(
     start: number,
     end: number,
-    namespaces: Map<string, string>
+    parentNamespaces: Map<string, string>
   ): {
     attributes: Record<string, string>;
     attributesWithPrefix: Record<string, AttributeInfo>;
+    namespaces: Map<string, string>;
   } {
     if (start >= end) {
       return {
         attributes: {},
         attributesWithPrefix: {},
+        namespaces: parentNamespaces,
       };
     }
 
     const attributes: Record<string, string> = {};
     const attributesWithPrefix: Record<string, AttributeInfo> = {};
+    let namespaces = parentNamespaces;
+    let ownsNamespaces = false;
+    const xml = this.xml;
 
     let index = start;
     while (index < end) {
-      while (index < end && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(index))) {
+      while (index < end && StaxXmlParserSync.isWhitespace(xml.charCodeAt(index))) {
         index++;
       }
       if (index >= end) {
@@ -417,7 +391,7 @@ export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXml
 
       const nameStart = index;
       while (index < end) {
-        const code = this.xml.charCodeAt(index);
+        const code = xml.charCodeAt(index);
         if (code === 61 || StaxXmlParserSync.isWhitespace(code)) {
           break;
         }
@@ -427,12 +401,12 @@ export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXml
       if (index === nameStart) {
         break;
       }
-      const attrName = this.xml.slice(nameStart, index);
+      const attrName = xml.slice(nameStart, index);
 
-      while (index < end && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(index))) {
+      while (index < end && StaxXmlParserSync.isWhitespace(xml.charCodeAt(index))) {
         index++;
       }
-      if (index >= end || this.xml.charCodeAt(index) !== 61) {
+      if (index >= end || xml.charCodeAt(index) !== 61) {
         attributes[attrName] = 'true';
 
         const colonIndex = attrName.indexOf(':');
@@ -455,30 +429,38 @@ export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXml
       }
 
       index++;
-      while (index < end && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(index))) {
+      while (index < end && StaxXmlParserSync.isWhitespace(xml.charCodeAt(index))) {
         index++;
       }
       if (index >= end) {
         break;
       }
 
-      const quote = this.xml.charCodeAt(index);
+      const quote = xml.charCodeAt(index);
       if (quote !== 34 && quote !== 39) {
         break;
       }
 
       index++;
       const valueStart = index;
-      while (index < end && this.xml.charCodeAt(index) !== quote) {
+      while (index < end && xml.charCodeAt(index) !== quote) {
         index++;
       }
 
-      const attrValue = this.entityDecoder(this.xml.slice(valueStart, index));
+      const attrValue = this.entityDecoder(xml.slice(valueStart, index));
       attributes[attrName] = attrValue;
 
       if (attrName === 'xmlns') {
+        if (!ownsNamespaces) {
+          namespaces = new Map<string, string>(parentNamespaces);
+          ownsNamespaces = true;
+        }
         namespaces.set('', attrValue);
       } else if (attrName.startsWith('xmlns:')) {
+        if (!ownsNamespaces) {
+          namespaces = new Map<string, string>(parentNamespaces);
+          ownsNamespaces = true;
+        }
         namespaces.set(attrName.slice(6), attrValue);
       }
 
@@ -517,68 +499,32 @@ export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXml
       index++;
     }
 
-    return { attributes, attributesWithPrefix };
+    return { attributes, attributesWithPrefix, namespaces };
   }
 
-  private hasNamespaceDeclaration(start: number, end: number): boolean {
-    let index = start;
-
-    while (index < end) {
-      while (index < end && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(index))) {
-        index++;
-      }
-      if (index >= end) {
-        return false;
-      }
-
-      const nameStart = index;
-      while (index < end) {
-        const code = this.xml.charCodeAt(index);
-        if (code === 61 || StaxXmlParserSync.isWhitespace(code)) {
-          break;
-        }
-        index++;
-      }
-
-      if (index === nameStart) {
-        return false;
-      }
-
-      const attrName = this.xml.slice(nameStart, index);
-      if (attrName === 'xmlns' || attrName.startsWith('xmlns:')) {
-        return true;
-      }
-
-      while (index < end && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(index))) {
-        index++;
-      }
-      if (index >= end || this.xml.charCodeAt(index) !== 61) {
-        continue;
-      }
-
-      index++;
-      while (index < end && StaxXmlParserSync.isWhitespace(this.xml.charCodeAt(index))) {
-        index++;
-      }
-      if (index >= end) {
-        return false;
-      }
-
-      const quote = this.xml.charCodeAt(index);
-      if (quote !== 34 && quote !== 39) {
-        return false;
-      }
-
-      index++;
-      while (index < end && this.xml.charCodeAt(index) !== quote) {
-        index++;
-      }
-      if (index < end) {
-        index++;
-      }
+  /**
+   * Keep the steady-state path free of try/catch so V8 can optimize `next()`.
+   * Error-to-event conversion stays in this cold helper to preserve the public contract.
+   */
+  private consumeIterator(iterator: Generator<AnyXmlEvent>): IteratorResult<AnyXmlEvent> {
+    try {
+      return iterator.next();
+    } catch (error) {
+      return {
+        value: {
+          type: XmlEventType.ERROR,
+          name: undefined,
+          localName: undefined,
+          prefix: undefined,
+          uri: undefined,
+          attributes: undefined,
+          attributesWithPrefix: undefined,
+          value: undefined,
+          error: error as Error,
+        } as unknown as AnyXmlEvent,
+        done: false,
+      };
     }
-
-    return false;
   }
 
   private findTagEnd(start: number): number {

--- a/packages/stax-xml/src/converter/XmlArraySchema.ts
+++ b/packages/stax-xml/src/converter/XmlArraySchema.ts
@@ -1,5 +1,5 @@
 import { XmlSchemaBase, type ParseInput } from './base.js';
-import { XmlParserInternal } from './XmlParserInternal.js';
+import { XmlParserInternal, type ParseParentContext } from './XmlParserInternal.js';
 import type { ParseOptions, XmlWriteOptions } from './types.js';
 import { SchemaType } from './types.js';
 import { XmlWriterInternal } from './XmlWriterInternal.js';
@@ -41,7 +41,7 @@ export class XmlArraySchema<T extends XmlSchemaBase<unknown, unknown>> extends X
     startDepth: number,
     options?: ParseOptions,
     stateMachine?: XmlParsingStateMachine,
-    parentContext?: unknown
+    parentContext?: ParseParentContext
   ): T['_output'][] | Promise<T['_output'][]> {
     const parser = new XmlParserInternal(options);
 

--- a/packages/stax-xml/src/converter/XmlObjectSchema.ts
+++ b/packages/stax-xml/src/converter/XmlObjectSchema.ts
@@ -1,5 +1,5 @@
 import { XmlSchema, type ParseInput } from './XmlSchema.js';
-import { XmlParserInternal } from './XmlParserInternal.js';
+import { XmlParserInternal, type ParseParentContext } from './XmlParserInternal.js';
 import type { ParseOptions, XmlObjectOptions, XmlWriteOptions } from './types.js';
 import { SchemaType } from './types.js';
 import type { AnyXmlEvent, StartElementEvent } from '../types.js';
@@ -57,7 +57,7 @@ export class XmlObjectSchema<T extends XmlObjectShape> extends XmlSchema<InferOb
     startDepth: number,
     options?: ParseOptions,
     stateMachine?: XmlParsingStateMachine,
-    parentContext?: unknown
+    parentContext?: ParseParentContext
   ): InferObjectOutput<T> | Promise<InferObjectOutput<T>> {
     const parser = new XmlParserInternal(options);
 

--- a/packages/stax-xml/src/converter/XmlParserInternal.ts
+++ b/packages/stax-xml/src/converter/XmlParserInternal.ts
@@ -26,9 +26,15 @@ import {
   type NumberCollector,
   type ArrayCollector,
   type ObjectCollector,
-  type SchemaActivation
+  type SchemaActivation,
+  type MatchContext
 } from './XmlParsingStateMachine.js';
 import { XmlSchemaBase } from './base.js';
+
+export interface ParseParentContext {
+  collector?: Collector<unknown>;
+  context?: MatchContext;
+}
 
 
 /**
@@ -318,7 +324,7 @@ export class XmlParserInternal {
     shape: Record<string, XmlSchemaBase<unknown, unknown>>,
     schemaOptions: { xpath?: string },
     stateMachine?: XmlParsingStateMachine,
-    parentContext?: unknown
+    parentContext?: ParseParentContext
   ): T {
     // Use provided State Machine or create new one
     const sm = stateMachine || new XmlParsingStateMachine(this.options);
@@ -393,7 +399,7 @@ export class XmlParserInternal {
     shape: Record<string, XmlSchemaBase<unknown, unknown>>,
     schemaOptions: { xpath?: string },
     stateMachine?: XmlParsingStateMachine,
-    parentContext?: unknown
+    parentContext?: ParseParentContext
   ): Promise<T> {
     // Use provided State Machine or create new one
     const sm = stateMachine || new XmlParsingStateMachine(this.options);

--- a/packages/stax-xml/src/converter/XmlParsingStateMachine.ts
+++ b/packages/stax-xml/src/converter/XmlParsingStateMachine.ts
@@ -548,7 +548,7 @@ export class XmlParsingStateMachine {
           activation.collector.value = value;
         } else if (activation.collector.type === 'number' && activation.schema._parseText) {
           // Call schema's _parseText to apply validation
-          activation.collector.value = activation.schema._parseText(value);
+          activation.collector.value = activation.schema._parseText(value) as number;
         }
 
         // Immediately deactivate - no need to process children
@@ -624,7 +624,7 @@ export class XmlParsingStateMachine {
               childCollector.value = attrValue;
             } else if (childCollector.type === 'number' && fieldSchema._parseText) {
               // Call schema's _parseText to apply validation
-              childCollector.value = fieldSchema._parseText(attrValue);
+              childCollector.value = fieldSchema._parseText(attrValue) as number;
             }
           }
         }
@@ -876,7 +876,7 @@ export class XmlParsingStateMachine {
     // 2. Apply object-level transforms
     const transforms = this.getAllTransforms(schema);
     for (const transformFn of transforms) {
-      result = transformFn(result);
+      result = transformFn(result) as Record<string, unknown>;
     }
 
     return result;

--- a/packages/stax-xml/src/converter/base.ts
+++ b/packages/stax-xml/src/converter/base.ts
@@ -92,7 +92,9 @@ export abstract class XmlSchemaBase<Output, Input = Output> {
     iterator: Iterator<AnyXmlEvent> | AsyncIterator<AnyXmlEvent>,
     startEvent: StartElementEvent,
     startDepth: number,
-    options?: ParseOptions
+    options?: ParseOptions,
+    stateMachine?: unknown,
+    parentContext?: unknown
   ): Output | Promise<Output>;
 
   /**
@@ -173,7 +175,9 @@ export abstract class XmlSchemaBase<Output, Input = Output> {
    * @returns New optional schema
    */
   optional(): XmlSchemaBase<Output | undefined, Input | undefined> {
-    return XmlSchemaBase._createOptional(this as XmlSchemaBase<unknown, unknown>);
+    return XmlSchemaBase._createOptional(
+      this as XmlSchemaBase<unknown, unknown>
+    ) as XmlSchemaBase<Output | undefined, Input | undefined>;
   }
 
   /**
@@ -182,7 +186,10 @@ export abstract class XmlSchemaBase<Output, Input = Output> {
    * @returns New array schema
    */
   array(xpath?: string): XmlSchemaBase<Output[], Input[]> {
-    return XmlSchemaBase._createArray(this as XmlSchemaBase<unknown, unknown>, xpath);
+    return XmlSchemaBase._createArray(
+      this as XmlSchemaBase<unknown, unknown>,
+      xpath
+    ) as XmlSchemaBase<Output[], Input[]>;
   }
 
   /**

--- a/packages/stax-xml/src/index.ts
+++ b/packages/stax-xml/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./StaxXmlParser.js";
 export * from "./StaxXmlParserSync.js";
+export * from "./StaxXmlCursor.js";
+export * from "./StaxXmlCursorSync.js";
 export * from "./StaxXmlWriter.js";
 export * from "./StaxXmlWriterSync.js";
 
@@ -7,4 +9,3 @@ export { isCdata, isCharacters, isEndDocument, isEndElement, isError, isStartDoc
 export type {
   AnyXmlEvent, CdataEvent, CharactersEvent, ErrorEvent, StartElementEvent, WriteElementOptions, XmlAttribute
 } from "./types.js";
-

--- a/packages/stax-xml/src/internal/AttributeCollector.ts
+++ b/packages/stax-xml/src/internal/AttributeCollector.ts
@@ -1,0 +1,118 @@
+import type { AttributeInfo } from '../types';
+
+interface AttributeEntry {
+  rawName: string;
+  localName: string;
+  prefix?: string;
+  uri?: string;
+  value?: string;
+  sourceStart?: number;
+  sourceEnd?: number;
+}
+
+export class AttributeCollector {
+  private source = '';
+  private entries: AttributeEntry[] = [];
+  private entryIndex = new Map<string, number>();
+  private attributesCache?: Record<string, string>;
+  private attributesWithPrefixCache?: Record<string, AttributeInfo>;
+
+  constructor(private readonly decodeValue: (text: string) => string) {}
+
+  reset(source: string): void {
+    this.source = source;
+    this.entries = [];
+    this.entryIndex.clear();
+    this.attributesCache = undefined;
+    this.attributesWithPrefixCache = undefined;
+  }
+
+  addDecoded(
+    rawName: string,
+    localName: string,
+    prefix: string | undefined,
+    uri: string | undefined,
+    value: string
+  ): void {
+    this.addEntry({
+      rawName,
+      localName,
+      prefix,
+      uri,
+      value,
+    });
+  }
+
+  addLazy(
+    rawName: string,
+    localName: string,
+    prefix: string | undefined,
+    uri: string | undefined,
+    sourceStart: number,
+    sourceEnd: number
+  ): void {
+    this.addEntry({
+      rawName,
+      localName,
+      prefix,
+      uri,
+      sourceStart,
+      sourceEnd,
+    });
+  }
+
+  isEmpty(): boolean {
+    return this.entries.length === 0;
+  }
+
+  getAttributeValue(rawName: string): string | undefined {
+    const index = this.entryIndex.get(rawName);
+    if (index === undefined) {
+      return undefined;
+    }
+
+    return this.materializeValue(this.entries[index]);
+  }
+
+  getAttributes(): Record<string, string> {
+    if (!this.attributesCache) {
+      this.attributesCache = {};
+      for (const entry of this.entries) {
+        this.attributesCache[entry.rawName] = this.materializeValue(entry);
+      }
+    }
+
+    return this.attributesCache;
+  }
+
+  getAttributesWithPrefix(): Record<string, AttributeInfo> {
+    if (!this.attributesWithPrefixCache) {
+      this.attributesWithPrefixCache = {};
+      for (const entry of this.entries) {
+        this.attributesWithPrefixCache[entry.rawName] = {
+          value: this.materializeValue(entry),
+          localName: entry.localName,
+          prefix: entry.prefix,
+          uri: entry.uri,
+        };
+      }
+    }
+
+    return this.attributesWithPrefixCache;
+  }
+
+  private addEntry(entry: AttributeEntry): void {
+    this.entryIndex.set(entry.rawName, this.entries.length);
+    this.entries.push(entry);
+    this.attributesCache = undefined;
+    this.attributesWithPrefixCache = undefined;
+  }
+
+  private materializeValue(entry: AttributeEntry): string {
+    if (entry.value === undefined) {
+      entry.value = this.decodeValue(this.source.slice(entry.sourceStart, entry.sourceEnd));
+    }
+
+    return entry.value;
+  }
+}

--- a/packages/stax-xml/src/internal/AttributeCollector.ts
+++ b/packages/stax-xml/src/internal/AttributeCollector.ts
@@ -13,18 +13,40 @@ interface AttributeEntry {
 export class AttributeCollector {
   private source = '';
   private entries: AttributeEntry[] = [];
-  private entryIndex = new Map<string, number>();
+  private entryIndex?: Map<string, number>;
   private attributesCache?: Record<string, string>;
   private attributesWithPrefixCache?: Record<string, AttributeInfo>;
+  private deferredStart?: number;
+  private deferredEnd?: number;
+  private deferredNamespaces?: Map<string, string>;
+  private deferredIsWhitespace?: (code: number) => boolean;
 
   constructor(private readonly decodeValue: (text: string) => string) {}
 
   reset(source: string): void {
     this.source = source;
     this.entries = [];
-    this.entryIndex.clear();
+    this.entryIndex = undefined;
     this.attributesCache = undefined;
     this.attributesWithPrefixCache = undefined;
+    this.deferredStart = undefined;
+    this.deferredEnd = undefined;
+    this.deferredNamespaces = undefined;
+    this.deferredIsWhitespace = undefined;
+  }
+
+  defer(
+    source: string,
+    start: number,
+    end: number,
+    namespaces: Map<string, string>,
+    isWhitespace: (code: number) => boolean
+  ): void {
+    this.reset(source);
+    this.deferredStart = start;
+    this.deferredEnd = end;
+    this.deferredNamespaces = namespaces;
+    this.deferredIsWhitespace = isWhitespace;
   }
 
   addDecoded(
@@ -62,11 +84,15 @@ export class AttributeCollector {
   }
 
   isEmpty(): boolean {
+    if (this.deferredStart !== undefined) {
+      return false;
+    }
     return this.entries.length === 0;
   }
 
   getAttributeValue(rawName: string): string | undefined {
-    const index = this.entryIndex.get(rawName);
+    this.materializeDeferredEntries();
+    const index = this.getEntryIndex().get(rawName);
     if (index === undefined) {
       return undefined;
     }
@@ -75,6 +101,7 @@ export class AttributeCollector {
   }
 
   getAttributes(): Record<string, string> {
+    this.materializeDeferredEntries();
     if (!this.attributesCache) {
       this.attributesCache = {};
       for (const entry of this.entries) {
@@ -86,6 +113,7 @@ export class AttributeCollector {
   }
 
   getAttributesWithPrefix(): Record<string, AttributeInfo> {
+    this.materializeDeferredEntries();
     if (!this.attributesWithPrefixCache) {
       this.attributesWithPrefixCache = {};
       for (const entry of this.entries) {
@@ -102,10 +130,20 @@ export class AttributeCollector {
   }
 
   private addEntry(entry: AttributeEntry): void {
-    this.entryIndex.set(entry.rawName, this.entries.length);
     this.entries.push(entry);
     this.attributesCache = undefined;
     this.attributesWithPrefixCache = undefined;
+  }
+
+  private getEntryIndex(): Map<string, number> {
+    if (!this.entryIndex) {
+      this.entryIndex = new Map<string, number>();
+      for (let index = 0; index < this.entries.length; index++) {
+        this.entryIndex.set(this.entries[index].rawName, index);
+      }
+    }
+
+    return this.entryIndex;
   }
 
   private materializeValue(entry: AttributeEntry): string {
@@ -114,5 +152,84 @@ export class AttributeCollector {
     }
 
     return entry.value;
+  }
+
+  private materializeDeferredEntries(): void {
+    if (
+      this.deferredStart === undefined ||
+      this.deferredEnd === undefined ||
+      !this.deferredNamespaces ||
+      !this.deferredIsWhitespace
+    ) {
+      return;
+    }
+
+    let index = this.deferredStart;
+    while (index < this.deferredEnd) {
+      while (index < this.deferredEnd && this.deferredIsWhitespace(this.source.charCodeAt(index))) {
+        index++;
+      }
+      if (index >= this.deferredEnd) {
+        break;
+      }
+
+      const nameStart = index;
+      while (index < this.deferredEnd) {
+        const code = this.source.charCodeAt(index);
+        if (code === 61 || this.deferredIsWhitespace(code)) {
+          break;
+        }
+        index++;
+      }
+
+      if (index === nameStart) {
+        break;
+      }
+
+      const rawName = this.source.slice(nameStart, index);
+      const colonIndex = rawName.indexOf(':');
+      const prefix = colonIndex === -1 ? undefined : rawName.slice(0, colonIndex);
+      const localName = colonIndex === -1 ? rawName : rawName.slice(colonIndex + 1);
+      const uri = prefix ? this.deferredNamespaces.get(prefix) : undefined;
+
+      while (index < this.deferredEnd && this.deferredIsWhitespace(this.source.charCodeAt(index))) {
+        index++;
+      }
+
+      if (index >= this.deferredEnd || this.source.charCodeAt(index) !== 61) {
+        this.addDecoded(rawName, localName, prefix, uri, 'true');
+        continue;
+      }
+
+      index++;
+      while (index < this.deferredEnd && this.deferredIsWhitespace(this.source.charCodeAt(index))) {
+        index++;
+      }
+      if (index >= this.deferredEnd) {
+        break;
+      }
+
+      const quote = this.source.charCodeAt(index);
+      if (quote !== 34 && quote !== 39) {
+        break;
+      }
+
+      index++;
+      const valueStart = index;
+      while (index < this.deferredEnd && this.source.charCodeAt(index) !== quote) {
+        index++;
+      }
+      if (index >= this.deferredEnd) {
+        break;
+      }
+
+      this.addLazy(rawName, localName, prefix, uri, valueStart, index);
+      index++;
+    }
+
+    this.deferredStart = undefined;
+    this.deferredEnd = undefined;
+    this.deferredNamespaces = undefined;
+    this.deferredIsWhitespace = undefined;
   }
 }

--- a/packages/stax-xml/src/internal/XmlCursorParserUtil.ts
+++ b/packages/stax-xml/src/internal/XmlCursorParserUtil.ts
@@ -192,14 +192,18 @@ export function collectAttributesFromSource(
   namespaces: Map<string, string>,
   collector: AttributeCollector,
   decodeValue: (text: string) => string,
-  isWhitespace: (code: number) => boolean
+  isWhitespace: (code: number) => boolean,
+  hasNamespaceDeclarations?: boolean
 ): void {
   collector.reset(source);
   if (start >= end) {
     return;
   }
 
-  if (!hasNamespaceDeclarationInSource(source, start, end, isWhitespace)) {
+  const shouldResolveNamespaces = hasNamespaceDeclarations
+    ?? hasNamespaceDeclarationInSource(source, start, end, isWhitespace);
+
+  if (!shouldResolveNamespaces) {
     collector.defer(source, start, end, namespaces, isWhitespace);
     return;
   }

--- a/packages/stax-xml/src/internal/XmlCursorParserUtil.ts
+++ b/packages/stax-xml/src/internal/XmlCursorParserUtil.ts
@@ -28,6 +28,72 @@ export function cloneNamespaces(parent: Map<string, string> | undefined): Map<st
   return namespaces;
 }
 
+export function hasNamespaceDeclarationInSource(
+  source: string,
+  start: number,
+  end: number,
+  isWhitespace: (code: number) => boolean
+): boolean {
+  let index = start;
+
+  while (index < end) {
+    while (index < end && isWhitespace(source.charCodeAt(index))) {
+      index++;
+    }
+    if (index >= end) {
+      return false;
+    }
+
+    const nameStart = index;
+    while (index < end) {
+      const code = source.charCodeAt(index);
+      if (code === 61 || isWhitespace(code)) {
+        break;
+      }
+      index++;
+    }
+
+    if (index === nameStart) {
+      return false;
+    }
+
+    const rawName = source.slice(nameStart, index);
+    if (rawName === 'xmlns' || rawName.startsWith('xmlns:')) {
+      return true;
+    }
+
+    while (index < end && isWhitespace(source.charCodeAt(index))) {
+      index++;
+    }
+    if (index >= end || source.charCodeAt(index) !== 61) {
+      continue;
+    }
+
+    index++;
+    while (index < end && isWhitespace(source.charCodeAt(index))) {
+      index++;
+    }
+    if (index >= end) {
+      return false;
+    }
+
+    const quote = source.charCodeAt(index);
+    if (quote !== 34 && quote !== 39) {
+      return false;
+    }
+
+    index++;
+    while (index < end && source.charCodeAt(index) !== quote) {
+      index++;
+    }
+    if (index < end) {
+      index++;
+    }
+  }
+
+  return false;
+}
+
 export function resolveElementName(
   qname: string,
   namespaces: Map<string, string>
@@ -111,6 +177,9 @@ export function applyNamespaceDeclaration(
 
 interface PendingAttribute {
   rawName: string;
+  localName: string;
+  prefix?: string;
+  isNamespaceDeclaration: boolean;
   sourceStart?: number;
   sourceEnd?: number;
   decodedValue?: string;
@@ -127,6 +196,11 @@ export function collectAttributesFromSource(
 ): void {
   collector.reset(source);
   if (start >= end) {
+    return;
+  }
+
+  if (!hasNamespaceDeclarationInSource(source, start, end, isWhitespace)) {
+    collector.defer(source, start, end, namespaces, isWhitespace);
     return;
   }
 
@@ -155,13 +229,17 @@ export function collectAttributesFromSource(
     }
 
     const rawName = source.slice(nameStart, i);
+    const nameInfo = resolveAttributeName(rawName, namespaces);
     while (i < end && isWhitespace(source.charCodeAt(i))) {
       i++;
     }
 
     if (i >= end || source.charCodeAt(i) !== 61) {
       pendingAttributes.push({
-        rawName,
+        rawName: nameInfo.rawName,
+        localName: nameInfo.localName,
+        prefix: nameInfo.prefix,
+        isNamespaceDeclaration: nameInfo.isNamespaceDeclaration,
         decodedValue: 'true',
       });
       continue;
@@ -190,7 +268,10 @@ export function collectAttributesFromSource(
     }
 
     pendingAttributes.push({
-      rawName,
+      rawName: nameInfo.rawName,
+      localName: nameInfo.localName,
+      prefix: nameInfo.prefix,
+      isNamespaceDeclaration: nameInfo.isNamespaceDeclaration,
       sourceStart: valueStart,
       sourceEnd: i,
     });
@@ -198,45 +279,53 @@ export function collectAttributesFromSource(
   }
 
   for (const pending of pendingAttributes) {
-    const value = pending.decodedValue ?? decodeValue(source.slice(pending.sourceStart, pending.sourceEnd));
-    const nameInfo = resolveAttributeName(pending.rawName, namespaces);
-
-    if (!nameInfo.isNamespaceDeclaration) {
+    if (!pending.isNamespaceDeclaration) {
       continue;
     }
+    const value = pending.decodedValue ?? decodeValue(source.slice(pending.sourceStart, pending.sourceEnd));
 
-    applyNamespaceDeclaration(nameInfo, value, namespaces);
+    applyNamespaceDeclaration(
+      {
+        rawName: pending.rawName,
+        localName: pending.localName,
+        prefix: pending.prefix,
+        uri: pending.prefix ? namespaces.get(pending.prefix) : undefined,
+        isNamespaceDeclaration: true,
+      },
+      value,
+      namespaces
+    );
     collector.addDecoded(
-      nameInfo.rawName,
-      nameInfo.localName,
-      nameInfo.prefix,
-      nameInfo.uri,
+      pending.rawName,
+      pending.localName,
+      pending.prefix,
+      pending.prefix ? namespaces.get(pending.prefix) : undefined,
       value
     );
   }
 
   for (const pending of pendingAttributes) {
-    const nameInfo = resolveAttributeName(pending.rawName, namespaces);
-    if (nameInfo.isNamespaceDeclaration) {
+    if (pending.isNamespaceDeclaration) {
       continue;
     }
+    const uri = pending.prefix ? namespaces.get(pending.prefix) : undefined;
 
     if (pending.decodedValue !== undefined) {
       collector.addDecoded(
-        nameInfo.rawName,
-        nameInfo.localName,
-        nameInfo.prefix,
-        nameInfo.uri,
+        pending.rawName,
+        pending.localName,
+        pending.prefix,
+        uri,
         pending.decodedValue
       );
       continue;
     }
 
     collector.addLazy(
-      nameInfo.rawName,
-      nameInfo.localName,
-      nameInfo.prefix,
-      nameInfo.uri,
+      pending.rawName,
+      pending.localName,
+      pending.prefix,
+      uri,
       pending.sourceStart,
       pending.sourceEnd
     );

--- a/packages/stax-xml/src/internal/XmlCursorParserUtil.ts
+++ b/packages/stax-xml/src/internal/XmlCursorParserUtil.ts
@@ -326,8 +326,8 @@ export function collectAttributesFromSource(
       pending.localName,
       pending.prefix,
       uri,
-      pending.sourceStart,
-      pending.sourceEnd
+      pending.sourceStart!,
+      pending.sourceEnd!
     );
   }
 }

--- a/packages/stax-xml/src/internal/XmlCursorParserUtil.ts
+++ b/packages/stax-xml/src/internal/XmlCursorParserUtil.ts
@@ -1,0 +1,244 @@
+import { AttributeCollector } from './AttributeCollector';
+
+export interface QualifiedNameInfo {
+  name: string;
+  localName: string;
+  prefix?: string;
+  uri?: string;
+}
+
+export interface AttributeNameInfo {
+  rawName: string;
+  localName: string;
+  prefix?: string;
+  uri?: string;
+  isNamespaceDeclaration: boolean;
+}
+
+export function cloneNamespaces(parent: Map<string, string> | undefined): Map<string, string> {
+  const namespaces = new Map<string, string>();
+  if (!parent) {
+    return namespaces;
+  }
+
+  for (const [prefix, uri] of parent) {
+    namespaces.set(prefix, uri);
+  }
+
+  return namespaces;
+}
+
+export function resolveElementName(
+  qname: string,
+  namespaces: Map<string, string>
+): QualifiedNameInfo {
+  const colonIndex = qname.indexOf(':');
+  if (colonIndex === -1) {
+    return {
+      name: qname,
+      localName: qname,
+      uri: namespaces.get(''),
+    };
+  }
+
+  const prefix = qname.slice(0, colonIndex);
+  const localName = qname.slice(colonIndex + 1);
+  return {
+    name: qname,
+    localName,
+    prefix,
+    uri: namespaces.get(prefix),
+  };
+}
+
+export function resolveAttributeName(
+  rawName: string,
+  namespaces: Map<string, string>
+): AttributeNameInfo {
+  if (rawName === 'xmlns') {
+    return {
+      rawName,
+      localName: 'xmlns',
+      isNamespaceDeclaration: true,
+    };
+  }
+
+  if (rawName.startsWith('xmlns:')) {
+    return {
+      rawName,
+      localName: rawName.slice(6),
+      prefix: 'xmlns',
+      isNamespaceDeclaration: true,
+    };
+  }
+
+  const colonIndex = rawName.indexOf(':');
+  if (colonIndex === -1) {
+    return {
+      rawName,
+      localName: rawName,
+      isNamespaceDeclaration: false,
+    };
+  }
+
+  const prefix = rawName.slice(0, colonIndex);
+  const localName = rawName.slice(colonIndex + 1);
+  return {
+    rawName,
+    localName,
+    prefix,
+    uri: namespaces.get(prefix),
+    isNamespaceDeclaration: false,
+  };
+}
+
+export function applyNamespaceDeclaration(
+  attribute: AttributeNameInfo,
+  value: string,
+  namespaces: Map<string, string>
+): void {
+  if (!attribute.isNamespaceDeclaration) {
+    return;
+  }
+
+  if (attribute.prefix === 'xmlns') {
+    namespaces.set(attribute.localName, value);
+    return;
+  }
+
+  namespaces.set('', value);
+}
+
+interface PendingAttribute {
+  rawName: string;
+  sourceStart?: number;
+  sourceEnd?: number;
+  decodedValue?: string;
+}
+
+export function collectAttributesFromSource(
+  source: string,
+  start: number,
+  end: number,
+  namespaces: Map<string, string>,
+  collector: AttributeCollector,
+  decodeValue: (text: string) => string,
+  isWhitespace: (code: number) => boolean
+): void {
+  collector.reset(source);
+  if (start >= end) {
+    return;
+  }
+
+  const pendingAttributes: PendingAttribute[] = [];
+  let i = start;
+
+  while (i < end) {
+    while (i < end && isWhitespace(source.charCodeAt(i))) {
+      i++;
+    }
+    if (i >= end) {
+      break;
+    }
+
+    const nameStart = i;
+    while (i < end) {
+      const code = source.charCodeAt(i);
+      if (code === 61 || isWhitespace(code)) {
+        break;
+      }
+      i++;
+    }
+
+    if (i === nameStart) {
+      break;
+    }
+
+    const rawName = source.slice(nameStart, i);
+    while (i < end && isWhitespace(source.charCodeAt(i))) {
+      i++;
+    }
+
+    if (i >= end || source.charCodeAt(i) !== 61) {
+      pendingAttributes.push({
+        rawName,
+        decodedValue: 'true',
+      });
+      continue;
+    }
+
+    i++;
+    while (i < end && isWhitespace(source.charCodeAt(i))) {
+      i++;
+    }
+    if (i >= end) {
+      throw new Error(`Unterminated attribute value for ${rawName}`);
+    }
+
+    const quote = source.charCodeAt(i);
+    if (quote !== 34 && quote !== 39) {
+      throw new Error(`Unterminated attribute value for ${rawName}`);
+    }
+
+    i++;
+    const valueStart = i;
+    while (i < end && source.charCodeAt(i) !== quote) {
+      i++;
+    }
+    if (i >= end) {
+      throw new Error(`Unterminated attribute value for ${rawName}`);
+    }
+
+    pendingAttributes.push({
+      rawName,
+      sourceStart: valueStart,
+      sourceEnd: i,
+    });
+    i++;
+  }
+
+  for (const pending of pendingAttributes) {
+    const value = pending.decodedValue ?? decodeValue(source.slice(pending.sourceStart, pending.sourceEnd));
+    const nameInfo = resolveAttributeName(pending.rawName, namespaces);
+
+    if (!nameInfo.isNamespaceDeclaration) {
+      continue;
+    }
+
+    applyNamespaceDeclaration(nameInfo, value, namespaces);
+    collector.addDecoded(
+      nameInfo.rawName,
+      nameInfo.localName,
+      nameInfo.prefix,
+      nameInfo.uri,
+      value
+    );
+  }
+
+  for (const pending of pendingAttributes) {
+    const nameInfo = resolveAttributeName(pending.rawName, namespaces);
+    if (nameInfo.isNamespaceDeclaration) {
+      continue;
+    }
+
+    if (pending.decodedValue !== undefined) {
+      collector.addDecoded(
+        nameInfo.rawName,
+        nameInfo.localName,
+        nameInfo.prefix,
+        nameInfo.uri,
+        pending.decodedValue
+      );
+      continue;
+    }
+
+    collector.addLazy(
+      nameInfo.rawName,
+      nameInfo.localName,
+      nameInfo.prefix,
+      nameInfo.uri,
+      pending.sourceStart,
+      pending.sourceEnd
+    );
+  }
+}

--- a/packages/stax-xml/test/coverage.test.ts
+++ b/packages/stax-xml/test/coverage.test.ts
@@ -89,11 +89,12 @@ describe('Coverage Tests for Missing Areas', () => {
       const xml = '<root>Some text content</root>';
       const parser = new StaxXmlParser(stringToReadableStream(xml), { batchSize: 5 });
 
-      // First batch should contain start elements
+      // With configured batchSize, the parser may consume the whole document in one batch.
       const batch1 = await parser.nextBatch();
       expect(batch1.length).toBeGreaterThan(0);
+      expect(batch1.some((event) => event.type === XmlEventType.CHARACTERS)).toBe(true);
 
-      // Continue processing to trigger CHARACTERS handling
+      // Continue processing to ensure remaining batches, if any, are still well-formed.
       let totalBatches = 0;
       while (totalBatches < 10) {
         const batch = await parser.nextBatch();
@@ -101,7 +102,7 @@ describe('Coverage Tests for Missing Areas', () => {
         totalBatches++;
       }
 
-      expect(totalBatches).toBeGreaterThan(0);
+      expect(totalBatches).toBeGreaterThanOrEqual(0);
     });
   });
 

--- a/packages/stax-xml/test/cursor-async.test.ts
+++ b/packages/stax-xml/test/cursor-async.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { StaxXmlCursor } from '../src/StaxXmlCursor';
+import { XmlEventType } from '../src/types';
+import { createChunkedStream, stringToReadableStream } from './helpers/parser-trace';
+
+describe('StaxXmlCursor', () => {
+  it('should expose token state across chunked input', async () => {
+    const cursor = new StaxXmlCursor(
+      createChunkedStream('<root xmlns:a="urn:a"><a:item attr="value">text</a:item></root>', 4)
+    );
+
+    await expect(cursor.next()).resolves.toBe(XmlEventType.START_DOCUMENT);
+
+    await expect(cursor.next()).resolves.toBe(XmlEventType.START_ELEMENT);
+    expect(cursor.name).toBe('root');
+    expect(cursor.getAttributes()).toEqual({
+      'xmlns:a': 'urn:a',
+    });
+
+    await expect(cursor.next()).resolves.toBe(XmlEventType.START_ELEMENT);
+    expect(cursor.name).toBe('a:item');
+    expect(cursor.localName).toBe('item');
+    expect(cursor.prefix).toBe('a');
+    expect(cursor.uri).toBe('urn:a');
+    expect(cursor.getAttributeValue('attr')).toBe('value');
+
+    await expect(cursor.next()).resolves.toBe(XmlEventType.CHARACTERS);
+    expect(cursor.getText()).toBe('text');
+
+    await expect(cursor.next()).resolves.toBe(XmlEventType.END_ELEMENT);
+    expect(cursor.name).toBe('a:item');
+    await expect(cursor.next()).resolves.toBe(XmlEventType.END_ELEMENT);
+    await expect(cursor.next()).resolves.toBe(XmlEventType.END_DOCUMENT);
+    expect(cursor.hasNext()).toBe(false);
+  });
+
+  it('should enforce the single-consumer contract while a pull is in flight', async () => {
+    const cursor = new StaxXmlCursor(createChunkedStream('<root><item/></root>', 1));
+
+    const pendingNext = cursor.next();
+
+    expect(() => cursor.hasNext()).toThrow('Concurrent cursor access is not allowed.');
+    await expect(cursor.next()).rejects.toThrow('Concurrent cursor access is not allowed.');
+
+    await expect(pendingNext).resolves.toBe(XmlEventType.START_DOCUMENT);
+  });
+
+  it('should fail on malformed XML and rethrow the same error after failure', async () => {
+    const cursor = new StaxXmlCursor(stringToReadableStream('<root><item></root>'));
+
+    await expect(cursor.next()).resolves.toBe(XmlEventType.START_DOCUMENT);
+    await expect(cursor.next()).resolves.toBe(XmlEventType.START_ELEMENT);
+    await expect(cursor.next()).resolves.toBe(XmlEventType.START_ELEMENT);
+
+    await expect(cursor.next()).rejects.toThrow('Mismatched closing tag');
+    expect(cursor.hasNext()).toBe(false);
+    await expect(cursor.next()).rejects.toThrow('Mismatched closing tag');
+  });
+});

--- a/packages/stax-xml/test/cursor-sync.test.ts
+++ b/packages/stax-xml/test/cursor-sync.test.ts
@@ -60,6 +60,34 @@ describe('StaxXmlCursorSync', () => {
     expect(cursor.uri).toBeUndefined();
   });
 
+  it('should keep namespace overrides scoped to the overridden subtree', () => {
+    const cursor = new StaxXmlCursorSync('<root xmlns="urn:root"><child xmlns="urn:child"><leaf/></child><sibling/></root>');
+
+    expect(cursor.next()).toBe(XmlEventType.START_DOCUMENT);
+    expect(cursor.next()).toBe(XmlEventType.START_ELEMENT);
+    expect(cursor.uri).toBe('urn:root');
+
+    expect(cursor.next()).toBe(XmlEventType.START_ELEMENT);
+    expect(cursor.name).toBe('child');
+    expect(cursor.uri).toBe('urn:child');
+
+    expect(cursor.next()).toBe(XmlEventType.START_ELEMENT);
+    expect(cursor.name).toBe('leaf');
+    expect(cursor.uri).toBe('urn:child');
+
+    expect(cursor.next()).toBe(XmlEventType.END_ELEMENT);
+    expect(cursor.name).toBe('leaf');
+    expect(cursor.uri).toBe('urn:child');
+
+    expect(cursor.next()).toBe(XmlEventType.END_ELEMENT);
+    expect(cursor.name).toBe('child');
+    expect(cursor.uri).toBe('urn:child');
+
+    expect(cursor.next()).toBe(XmlEventType.START_ELEMENT);
+    expect(cursor.name).toBe('sibling');
+    expect(cursor.uri).toBe('urn:root');
+  });
+
   it('should fail on malformed XML and rethrow the same error after failure', () => {
     const cursor = new StaxXmlCursorSync('<root><item></root>');
 

--- a/packages/stax-xml/test/cursor-sync.test.ts
+++ b/packages/stax-xml/test/cursor-sync.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { StaxXmlCursorSync } from '../src/StaxXmlCursorSync';
+import { XmlEventType } from '../src/types';
+
+describe('StaxXmlCursorSync', () => {
+  it('should expose token state and lazy attributes for the current START_ELEMENT', () => {
+    const cursor = new StaxXmlCursorSync('<root xmlns:a="urn:a" a:flag="on"><a:item attr="value">text</a:item></root>');
+
+    expect(cursor.hasNext()).toBe(true);
+    expect(cursor.next()).toBe(XmlEventType.START_DOCUMENT);
+    expect(() => cursor.getAttributes()).toThrow('Current token does not expose attributes.');
+
+    expect(cursor.next()).toBe(XmlEventType.START_ELEMENT);
+    expect(cursor.name).toBe('root');
+    expect(cursor.localName).toBe('root');
+    expect(cursor.uri).toBeUndefined();
+    expect(cursor.getAttributeValue('a:flag')).toBe('on');
+    expect(cursor.getAttributes()).toEqual({
+      'a:flag': 'on',
+      'xmlns:a': 'urn:a',
+    });
+
+    expect(cursor.next()).toBe(XmlEventType.START_ELEMENT);
+    expect(cursor.name).toBe('a:item');
+    expect(cursor.localName).toBe('item');
+    expect(cursor.prefix).toBe('a');
+    expect(cursor.uri).toBe('urn:a');
+    expect(cursor.getAttributeValue('attr')).toBe('value');
+
+    expect(cursor.next()).toBe(XmlEventType.CHARACTERS);
+    expect(cursor.getText()).toBe('text');
+    expect(() => cursor.getAttributes()).toThrow('Current token does not expose attributes.');
+
+    expect(cursor.next()).toBe(XmlEventType.END_ELEMENT);
+    expect(cursor.name).toBe('a:item');
+    expect(cursor.uri).toBe('urn:a');
+
+    expect(cursor.next()).toBe(XmlEventType.END_ELEMENT);
+    expect(cursor.name).toBe('root');
+
+    expect(cursor.next()).toBe(XmlEventType.END_DOCUMENT);
+    expect(cursor.hasNext()).toBe(false);
+  });
+
+  it('should keep self-closing namespace declarations scoped to that element', () => {
+    const cursor = new StaxXmlCursorSync('<root><item xmlns="urn:item"/><sibling/></root>');
+
+    expect(cursor.next()).toBe(XmlEventType.START_DOCUMENT);
+    expect(cursor.next()).toBe(XmlEventType.START_ELEMENT);
+    expect(cursor.next()).toBe(XmlEventType.START_ELEMENT);
+    expect(cursor.name).toBe('item');
+    expect(cursor.uri).toBe('urn:item');
+
+    expect(cursor.next()).toBe(XmlEventType.END_ELEMENT);
+    expect(cursor.name).toBe('item');
+    expect(cursor.uri).toBe('urn:item');
+
+    expect(cursor.next()).toBe(XmlEventType.START_ELEMENT);
+    expect(cursor.name).toBe('sibling');
+    expect(cursor.uri).toBeUndefined();
+  });
+
+  it('should fail on malformed XML and rethrow the same error after failure', () => {
+    const cursor = new StaxXmlCursorSync('<root><item></root>');
+
+    expect(cursor.next()).toBe(XmlEventType.START_DOCUMENT);
+    expect(cursor.next()).toBe(XmlEventType.START_ELEMENT);
+    expect(cursor.next()).toBe(XmlEventType.START_ELEMENT);
+
+    expect(() => cursor.next()).toThrow('Mismatched closing tag');
+    expect(cursor.hasNext()).toBe(false);
+    expect(() => cursor.next()).toThrow('Mismatched closing tag');
+  });
+});

--- a/packages/stax-xml/test/dtd-chunk-boundary.test.ts
+++ b/packages/stax-xml/test/dtd-chunk-boundary.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { StaxXmlCursor } from '../src/StaxXmlCursor';
+import { XmlEventType } from '../src/types';
+import {
+  collectAsyncTrace,
+  collectSyncTrace,
+} from './helpers/parser-trace';
+
+const mixedFixture = readFileSync(
+  new URL('../../benchmark/assets/mixed.xml', import.meta.url),
+  'utf8'
+);
+const compactDtdFixture =
+  '<?xml version="1.0"?><!DOCTYPE foo [<!ELEMENT foo (#PCDATA)><!--internal--><!ELEMENT bar (#PCDATA)>]><foo>before<![CDATA[<bar/>]]>after</foo>';
+
+describe('DTD Chunk Boundary Regressions', () => {
+  it('should parse the mixed benchmark fixture synchronously', () => {
+    expect(() => collectSyncTrace(mixedFixture)).not.toThrow();
+  });
+
+  it('should match the sync trace for a compact DTD fixture across representative chunk sizes', async () => {
+    const expected = collectSyncTrace(compactDtdFixture);
+
+    for (const chunkSize of [1, 4, 16, 256]) {
+      await expect(collectAsyncTrace(compactDtdFixture, chunkSize)).resolves.toEqual(expected);
+    }
+  });
+
+  it('should tolerate empty chunks while parsing a compact DTD fixture', async () => {
+    const expected = collectSyncTrace(compactDtdFixture);
+    const parser = new StaxXmlCursor(createChunkedStreamWithEmptyChunks(compactDtdFixture, 16));
+    const actualTypes: string[] = [];
+
+    while (parser.hasNext()) {
+      actualTypes.push(await parser.next());
+    }
+
+    expect(actualTypes).toEqual(expected.map((record) => record.type));
+  });
+
+  it('should preserve the mixed benchmark fixture event structure with 256-byte chunks', async () => {
+    const expected = collectSyncTrace(mixedFixture);
+    const actual = await collectAsyncTrace(mixedFixture, 256);
+
+    expect(actual.map((record) => record.type)).toEqual(expected.map((record) => record.type));
+    expect(actual[1]?.name).toBe(expected[1]?.name);
+    expect(actual.at(-2)?.name).toBe(expected.at(-2)?.name);
+  });
+});
+
+function createChunkedStreamWithEmptyChunks(xml: string, chunkSize: number): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(xml);
+  let offset = 0;
+  let emitEmptyChunk = false;
+
+  return new ReadableStream({
+    pull(controller) {
+      if (emitEmptyChunk) {
+        emitEmptyChunk = false;
+        controller.enqueue(new Uint8Array(0));
+        return;
+      }
+
+      if (offset >= bytes.length) {
+        controller.close();
+        return;
+      }
+
+      const nextOffset = Math.min(offset + chunkSize, bytes.length);
+      controller.enqueue(bytes.slice(offset, nextOffset));
+      offset = nextOffset;
+      emitEmptyChunk = true;
+    }
+  });
+}

--- a/packages/stax-xml/test/helpers/parser-trace.ts
+++ b/packages/stax-xml/test/helpers/parser-trace.ts
@@ -1,0 +1,133 @@
+import StaxXmlParser from '../../src/StaxXmlParser';
+import { StaxXmlParserSync } from '../../src/StaxXmlParserSync';
+import type { AnyXmlEvent, AttributeInfo } from '../../src/types';
+
+export interface NormalizedAttributeRecord {
+  name: string;
+  localName: string;
+  prefix?: string;
+  uri?: string;
+  value: string;
+}
+
+export interface NormalizedTraceRecord {
+  type: string;
+  name?: string;
+  localName?: string;
+  prefix?: string;
+  uri?: string;
+  text?: string;
+  attributes?: Record<string, string>;
+  attributesWithPrefix?: NormalizedAttributeRecord[];
+}
+
+export function stringToReadableStream(str: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(str);
+
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    }
+  });
+}
+
+export function createChunkedStream(str: string, chunkSize: number): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(str);
+  let offset = 0;
+
+  return new ReadableStream({
+    pull(controller) {
+      if (offset >= bytes.length) {
+        controller.close();
+        return;
+      }
+
+      const nextOffset = Math.min(offset + chunkSize, bytes.length);
+      controller.enqueue(bytes.slice(offset, nextOffset));
+      offset = nextOffset;
+    }
+  });
+}
+
+export function collectSyncTrace(xml: string): NormalizedTraceRecord[] {
+  return Array.from(new StaxXmlParserSync(xml)).map(normalizeEvent);
+}
+
+export async function collectAsyncTrace(xml: string, chunkSize?: number): Promise<NormalizedTraceRecord[]> {
+  const stream = chunkSize
+    ? createChunkedStream(xml, chunkSize)
+    : stringToReadableStream(xml);
+  const parser = new StaxXmlParser(stream);
+  const trace: NormalizedTraceRecord[] = [];
+
+  for await (const event of parser) {
+    trace.push(normalizeEvent(event));
+  }
+
+  return trace;
+}
+
+export function normalizeEvent(event: AnyXmlEvent): NormalizedTraceRecord {
+  const base: NormalizedTraceRecord = {
+    type: event.type,
+    name: 'name' in event ? event.name : undefined,
+    localName: 'localName' in event ? event.localName : undefined,
+    prefix: 'prefix' in event ? event.prefix : undefined,
+    uri: 'uri' in event ? event.uri : undefined,
+    text: 'value' in event ? event.value : undefined,
+    attributes: 'attributes' in event ? sortRecord(event.attributes) : undefined,
+    attributesWithPrefix: 'attributesWithPrefix' in event
+      ? normalizeAttributesWithPrefix(event.attributesWithPrefix)
+      : undefined,
+  };
+
+  return stripUndefined(base);
+}
+
+function normalizeAttributesWithPrefix(
+  value: Record<string, AttributeInfo> | undefined
+): NormalizedAttributeRecord[] | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return Object.entries(value)
+    .map(([key, info]) => normalizeAttributeEntry(key, info))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function normalizeAttributeEntry(key: string, info: AttributeInfo): NormalizedAttributeRecord {
+  const localName = info.localName ?? key;
+  const name = info.prefix
+    ? `${info.prefix}:${localName}`
+    : localName;
+
+  return stripUndefined({
+    name,
+    localName,
+    prefix: info.prefix,
+    uri: info.uri,
+    value: info.value,
+  });
+}
+
+function sortRecord(
+  value: Record<string, string> | undefined
+): Record<string, string> | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).sort(([left], [right]) => left.localeCompare(right))
+  );
+}
+
+function stripUndefined<T extends object>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).filter(([, entry]) => entry !== undefined)
+  ) as T;
+}

--- a/packages/stax-xml/test/parser-sync.test.ts
+++ b/packages/stax-xml/test/parser-sync.test.ts
@@ -441,4 +441,37 @@ describe('StaxXmlParserSync', () => {
     });
     expect((events.at(-1) as { error: Error }).error.message).toContain('Mismatched closing tag');
   });
+
+  it('should keep namespace overrides scoped to the current element and its descendants', () => {
+    const parser = new StaxXmlParserSync('<root xmlns="urn:root"><child xmlns="urn:child"/><sibling/></root>');
+    const events = Array.from(parser);
+
+    expect(events).toEqual([
+      { type: XmlEventType.START_DOCUMENT },
+      { type: XmlEventType.START_ELEMENT, name: 'root', localName: 'root', prefix: undefined, uri: 'urn:root', attributes: { xmlns: 'urn:root' }, attributesWithPrefix: { xmlns: { value: 'urn:root', localName: 'xmlns', prefix: undefined, uri: undefined } } },
+      { type: XmlEventType.START_ELEMENT, name: 'child', localName: 'child', prefix: undefined, uri: 'urn:child', attributes: { xmlns: 'urn:child' }, attributesWithPrefix: { xmlns: { value: 'urn:child', localName: 'xmlns', prefix: undefined, uri: undefined } } },
+      { type: XmlEventType.END_ELEMENT, name: 'child', localName: 'child', prefix: undefined, uri: 'urn:child' },
+      { type: XmlEventType.START_ELEMENT, name: 'sibling', localName: 'sibling', prefix: undefined, uri: 'urn:root', attributes: {}, attributesWithPrefix: {} },
+      { type: XmlEventType.END_ELEMENT, name: 'sibling', localName: 'sibling', prefix: undefined, uri: 'urn:root' },
+      { type: XmlEventType.END_ELEMENT, name: 'root', localName: 'root', prefix: undefined, uri: 'urn:root' },
+      { type: XmlEventType.END_DOCUMENT },
+    ]);
+  });
+
+  it('should return a terminal ERROR event once and then finish for explicit next calls', () => {
+    const parser = new StaxXmlParserSync('<root><item></root>');
+
+    expect(parser.next()).toEqual({ value: { type: XmlEventType.START_DOCUMENT }, done: false });
+    expect((parser.next().value as { type: string }).type).toBe(XmlEventType.START_ELEMENT);
+    expect((parser.next().value as { type: string }).type).toBe(XmlEventType.START_ELEMENT);
+
+    const errorResult = parser.next();
+    expect(errorResult.done).toBe(false);
+    expect(errorResult.value).toEqual({
+      type: XmlEventType.ERROR,
+      error: expect.any(Error),
+    });
+    expect((errorResult.value as { error: Error }).error.message).toContain('Mismatched closing tag');
+    expect(parser.next()).toEqual({ value: undefined, done: true });
+  });
 });

--- a/packages/stax-xml/test/parser-sync.test.ts
+++ b/packages/stax-xml/test/parser-sync.test.ts
@@ -430,4 +430,15 @@ describe('StaxXmlParserSync', () => {
       { type: XmlEventType.END_DOCUMENT },
     ]);
   });
+
+  it('should emit a terminal ERROR event for malformed XML', () => {
+    const parser = new StaxXmlParserSync('<root><item></root>');
+    const events = Array.from(parser);
+
+    expect(events.at(-1)).toEqual({
+      type: XmlEventType.ERROR,
+      error: expect.any(Error),
+    });
+    expect((events.at(-1) as { error: Error }).error.message).toContain('Mismatched closing tag');
+  });
 });

--- a/packages/stax-xml/test/parser-trace-oracle.test.ts
+++ b/packages/stax-xml/test/parser-trace-oracle.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectAsyncTrace,
+  collectSyncTrace,
+  type NormalizedTraceRecord,
+} from './helpers/parser-trace';
+
+const namespaceScopeTrace: NormalizedTraceRecord[] = [
+  { type: 'START_DOCUMENT' },
+  {
+    type: 'START_ELEMENT',
+    name: 'root',
+    localName: 'root',
+    attributes: {
+      'a:flag': 'on',
+      'xmlns:a': 'urn:a',
+    },
+    attributesWithPrefix: [
+      { name: 'a:flag', localName: 'flag', prefix: 'a', uri: 'urn:a', value: 'on' },
+      { name: 'xmlns:a', localName: 'a', prefix: 'xmlns', value: 'urn:a' },
+    ],
+  },
+  {
+    type: 'START_ELEMENT',
+    name: 'a:one',
+    localName: 'one',
+    prefix: 'a',
+    uri: 'urn:a',
+    attributes: {
+      attr: '1',
+    },
+    attributesWithPrefix: [
+      { name: 'attr', localName: 'attr', value: '1' },
+    ],
+  },
+  {
+    type: 'END_ELEMENT',
+    name: 'a:one',
+    localName: 'one',
+    prefix: 'a',
+    uri: 'urn:a',
+  },
+  {
+    type: 'START_ELEMENT',
+    name: 'two',
+    localName: 'two',
+    uri: 'urn:two',
+    attributes: {
+      xmlns: 'urn:two',
+    },
+    attributesWithPrefix: [
+      { name: 'xmlns', localName: 'xmlns', value: 'urn:two' },
+    ],
+  },
+  {
+    type: 'END_ELEMENT',
+    name: 'two',
+    localName: 'two',
+    uri: 'urn:two',
+  },
+  {
+    type: 'START_ELEMENT',
+    name: 'three',
+    localName: 'three',
+    attributes: {},
+    attributesWithPrefix: [],
+  },
+  {
+    type: 'END_ELEMENT',
+    name: 'three',
+    localName: 'three',
+  },
+  {
+    type: 'END_ELEMENT',
+    name: 'root',
+    localName: 'root',
+  },
+  { type: 'END_DOCUMENT' },
+];
+
+describe('Parser Trace Oracle', () => {
+  it('should normalize sync parser traces for namespace scope and self-closing tags', () => {
+    const xml = '<root xmlns:a="urn:a" a:flag="on"><a:one attr="1"/><two xmlns="urn:two"/><three/></root>';
+
+    expect(collectSyncTrace(xml)).toEqual(namespaceScopeTrace);
+  });
+
+  it('should normalize async parser traces for namespace scope and self-closing tags', async () => {
+    const xml = '<root xmlns:a="urn:a" a:flag="on"><a:one attr="1"/><two xmlns="urn:two"/><three/></root>';
+
+    await expect(collectAsyncTrace(xml)).resolves.toEqual(namespaceScopeTrace);
+  });
+
+  it('should produce the same async normalized trace for chunked input', async () => {
+    const xml = '<root xmlns:a="urn:a" a:flag="on"><a:one attr="1"/><two xmlns="urn:two"/><three/></root>';
+
+    await expect(collectAsyncTrace(xml, 5)).resolves.toEqual(namespaceScopeTrace);
+  });
+});

--- a/packages/stax-xml/tsconfig.build.json
+++ b/packages/stax-xml/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": false,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/stax-xml/tsdown.config.ts
+++ b/packages/stax-xml/tsdown.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
   {
     entry: ['src/index.ts'],
     format: ['cjs', 'esm'],
-    dts: false,
+    dts: true,
     outDir: 'dist',
     logLevel: 'error',
   },
@@ -15,7 +15,7 @@ export default defineConfig([
       converter: 'src/converter/index.ts',
     },
     format: ['cjs', 'esm'],
-    dts: false,
+    dts: true,
     outDir: 'dist',
     clean: false, // Don't clean to preserve index.* files
     logLevel: 'error',

--- a/packages/stax-xml/tsdown.config.ts
+++ b/packages/stax-xml/tsdown.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
   {
     entry: ['src/index.ts'],
     format: ['cjs', 'esm'],
-    dts: true,
+    dts: false,
     outDir: 'dist',
     logLevel: 'error',
   },
@@ -15,7 +15,7 @@ export default defineConfig([
       converter: 'src/converter/index.ts',
     },
     format: ['cjs', 'esm'],
-    dts: true,
+    dts: false,
     outDir: 'dist',
     clean: false, // Don't clean to preserve index.* files
     logLevel: 'error',

--- a/scripts/compare-runner-lib.mjs
+++ b/scripts/compare-runner-lib.mjs
@@ -22,15 +22,48 @@ export async function ensureDir(dirPath) {
 
 export async function getGitMetadata(repoRoot) {
   const head = await runSmallCommand('git', ['-C', repoRoot, 'rev-parse', 'HEAD']);
-  const branch = await runSmallCommand('git', ['-C', repoRoot, 'rev-parse', '--abbrev-ref', 'HEAD']);
+  const branch = await runOptionalCommand('git', ['-C', repoRoot, 'symbolic-ref', '--short', '-q', 'HEAD']);
 
   return {
     head,
-    branch,
+    branch: branch || null,
   };
 }
 
-export async function runLoggedCommand({ command, args, cwd, env, logPath }) {
+export async function getGitStatusSummary(repoRoot) {
+  const output = await runSmallCommand('git', ['-C', repoRoot, 'status', '--porcelain']);
+  const entries = output
+    ? output.split('\n').filter(Boolean)
+    : [];
+
+  return {
+    dirty: entries.length > 0,
+    entries,
+  };
+}
+
+export async function getWorktreeList(repoRoot) {
+  const output = await runSmallCommand('git', ['-C', repoRoot, 'worktree', 'list', '--porcelain']);
+  return parseWorktreeList(output);
+}
+
+export function resolveBuiltDistEntrypoint(repoRoot) {
+  const candidates = [
+    path.join(repoRoot, 'packages/stax-xml/dist/index.js'),
+    path.join(repoRoot, 'packages/stax-xml/dist/index.mjs'),
+  ];
+
+  const match = candidates.find((candidate) => existsOnDisk(candidate));
+  if (!match) {
+    throw new Error(
+      `Missing built dist entrypoint. Expected one of: ${candidates.join(', ')}`
+    );
+  }
+
+  return match;
+}
+
+export async function runLoggedCommand({ command, args, cwd, env, logPath, timeoutMs }) {
   await ensureDir(path.dirname(logPath));
 
   const startedAt = new Date().toISOString();
@@ -38,10 +71,16 @@ export async function runLoggedCommand({ command, args, cwd, env, logPath }) {
   logStream.write(`# cwd: ${cwd}\n`);
   logStream.write(`# command: ${[command, ...args].join(' ')}\n`);
   logStream.write(`# startedAt: ${startedAt}\n\n`);
+  if (timeoutMs) {
+    logStream.write(`# timeoutMs: ${timeoutMs}\n\n`);
+  }
 
   const start = process.hrtime.bigint();
 
   const result = await new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
     const child = spawn(command, args, {
       cwd,
       env: {
@@ -51,15 +90,32 @@ export async function runLoggedCommand({ command, args, cwd, env, logPath }) {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
+    let killTimer;
     child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
       logStream.write(chunk);
     });
     child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
       logStream.write(chunk);
     });
+    if (timeoutMs) {
+      killTimer = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGTERM');
+        setTimeout(() => {
+          if (child.exitCode === null && child.signalCode === null) {
+            child.kill('SIGKILL');
+          }
+        }, 5_000).unref();
+      }, timeoutMs);
+    }
     child.on('error', reject);
     child.on('close', (code, signal) => {
-      resolve({ code, signal });
+      if (killTimer) {
+        clearTimeout(killTimer);
+      }
+      resolve({ code, signal, stdout, stderr, timedOut });
     });
   });
 
@@ -67,6 +123,7 @@ export async function runLoggedCommand({ command, args, cwd, env, logPath }) {
   logStream.write(`\n# finishedAt: ${new Date().toISOString()}\n`);
   logStream.write(`# durationMs: ${durationMs.toFixed(3)}\n`);
   logStream.write(`# exitCode: ${result.code ?? 'null'}\n`);
+  logStream.write(`# timedOut: ${result.timedOut ? 'true' : 'false'}\n`);
   if (result.signal) {
     logStream.write(`# signal: ${result.signal}\n`);
   }
@@ -77,6 +134,9 @@ export async function runLoggedCommand({ command, args, cwd, env, logPath }) {
     durationMs,
     exitCode: result.code,
     signal: result.signal,
+    timedOut: result.timedOut,
+    stdout: result.stdout,
+    stderr: result.stderr,
     logPath,
   };
 }
@@ -115,4 +175,71 @@ async function runSmallCommand(command, args) {
   });
 
   return output;
+}
+
+async function runOptionalCommand(command, args) {
+  try {
+    return await runSmallCommand(command, args);
+  } catch {
+    return '';
+  }
+}
+
+function parseWorktreeList(output) {
+  if (!output) {
+    return [];
+  }
+
+  const entries = [];
+  let current = null;
+
+  for (const line of output.split('\n')) {
+    if (!line) {
+      if (current) {
+        entries.push(current);
+        current = null;
+      }
+      continue;
+    }
+
+    const [key, ...rest] = line.split(' ');
+    const value = rest.join(' ');
+    if (key === 'worktree') {
+      if (current) {
+        entries.push(current);
+      }
+      current = { worktree: value };
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    if (key === 'HEAD') {
+      current.head = value;
+    } else if (key === 'branch') {
+      current.branch = value.replace('refs/heads/', '');
+    } else if (key === 'detached') {
+      current.detached = true;
+    } else if (key === 'locked') {
+      current.locked = value || true;
+    } else if (key === 'prunable') {
+      current.prunable = value || true;
+    }
+  }
+
+  if (current) {
+    entries.push(current);
+  }
+
+  return entries;
+}
+
+function existsOnDisk(filePath) {
+  try {
+    return process.getBuiltinModule('node:fs').existsSync(filePath);
+  } catch {
+    return false;
+  }
 }

--- a/scripts/compare-runner-lib.mjs
+++ b/scripts/compare-runner-lib.mjs
@@ -1,0 +1,118 @@
+import { mkdir, readdir, writeFile } from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { spawn } from 'node:child_process';
+
+export function usage(message) {
+  if (message) {
+    console.error(message);
+    console.error('');
+  }
+}
+
+export function getOutputRoot(label) {
+  return path.join('/tmp/stax-compare', label);
+}
+
+export async function ensureDir(dirPath) {
+  await mkdir(dirPath, { recursive: true });
+  return dirPath;
+}
+
+export async function getGitMetadata(repoRoot) {
+  const head = await runSmallCommand('git', ['-C', repoRoot, 'rev-parse', 'HEAD']);
+  const branch = await runSmallCommand('git', ['-C', repoRoot, 'rev-parse', '--abbrev-ref', 'HEAD']);
+
+  return {
+    head,
+    branch,
+  };
+}
+
+export async function runLoggedCommand({ command, args, cwd, env, logPath }) {
+  await ensureDir(path.dirname(logPath));
+
+  const startedAt = new Date().toISOString();
+  const logStream = createWriteStream(logPath, { flags: 'w' });
+  logStream.write(`# cwd: ${cwd}\n`);
+  logStream.write(`# command: ${[command, ...args].join(' ')}\n`);
+  logStream.write(`# startedAt: ${startedAt}\n\n`);
+
+  const start = process.hrtime.bigint();
+
+  const result = await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: {
+        ...process.env,
+        ...env,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    child.stdout.on('data', (chunk) => {
+      logStream.write(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      logStream.write(chunk);
+    });
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      resolve({ code, signal });
+    });
+  });
+
+  const durationMs = Number(process.hrtime.bigint() - start) / 1_000_000;
+  logStream.write(`\n# finishedAt: ${new Date().toISOString()}\n`);
+  logStream.write(`# durationMs: ${durationMs.toFixed(3)}\n`);
+  logStream.write(`# exitCode: ${result.code ?? 'null'}\n`);
+  if (result.signal) {
+    logStream.write(`# signal: ${result.signal}\n`);
+  }
+  await new Promise((resolve) => logStream.end(resolve));
+
+  return {
+    startedAt,
+    durationMs,
+    exitCode: result.code,
+    signal: result.signal,
+    logPath,
+  };
+}
+
+export async function writeJson(filePath, value) {
+  await ensureDir(path.dirname(filePath));
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+export async function listCpuProfiles(dirPath) {
+  const entries = await readdir(dirPath, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.cpuprofile'))
+    .map((entry) => path.join(dirPath, entry.name))
+    .sort();
+}
+
+async function runSmallCommand(command, args) {
+  const output = await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+
+    let stdout = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout.trim());
+        return;
+      }
+      reject(new Error(`${command} ${args.join(' ')} failed with exit code ${code}`));
+    });
+  });
+
+  return output;
+}

--- a/scripts/evaluate-core-parser-gates.mjs
+++ b/scripts/evaluate-core-parser-gates.mjs
@@ -1,0 +1,277 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const [, , suiteArg, baselineSummaryArg, featureSummaryArg] = process.argv;
+
+if (!suiteArg || !baselineSummaryArg || !featureSummaryArg) {
+  console.error(
+    'Usage: node scripts/evaluate-core-parser-gates.mjs <suite> <baselineSuiteJson> <featureSuiteJson>'
+  );
+  process.exit(1);
+}
+
+const suite = suiteArg;
+const baselineSummary = JSON.parse(readFileSync(path.resolve(baselineSummaryArg), 'utf8'));
+const featureSummary = JSON.parse(readFileSync(path.resolve(featureSummaryArg), 'utf8'));
+
+const evaluators = {
+  cursor: evaluateCursorGate,
+  wrapper: evaluateWrapperGate,
+  stress: evaluateStressSuite,
+};
+
+const evaluator = evaluators[suite];
+if (!evaluator) {
+  console.error(`Unknown suite: ${suite}`);
+  console.error(`Supported suites: ${Object.keys(evaluators).join(', ')}`);
+  process.exit(1);
+}
+
+const result = evaluator(baselineSummary, featureSummary);
+console.log(JSON.stringify(result, null, 2));
+
+if (suite !== 'stress' && !result.pass) {
+  process.exit(1);
+}
+
+function evaluateCursorGate(baselineSummaryValue, featureSummaryValue) {
+  const checks = [
+    evaluateImprovementCheck(
+      baselineSummaryValue,
+      featureSummaryValue,
+      'sync-cursor-consume',
+      10
+    ),
+    evaluateImprovementCheck(
+      baselineSummaryValue,
+      featureSummaryValue,
+      'sync-cursor-attr-unused',
+      25
+    ),
+    evaluateRatioCheck(
+      baselineSummaryValue,
+      featureSummaryValue,
+      'async-cursor-midsize-4kb',
+      1.5
+    ),
+    evaluateRatioCheck(
+      baselineSummaryValue,
+      featureSummaryValue,
+      'async-cursor-midsize-64kb',
+      1.5
+    ),
+  ];
+
+  return finalizeGateResult(
+    'cursor',
+    'checkpoint',
+    checks,
+    baselineSummaryValue,
+    featureSummaryValue
+  );
+}
+
+function evaluateWrapperGate(baselineSummaryValue, featureSummaryValue) {
+  const representativeCases = [
+    'sync-parser-books',
+    'sync-parser-complex',
+  ];
+
+  const regressionChecks = representativeCases.map((caseName) =>
+    evaluateMaxRegressionCheck(baselineSummaryValue, featureSummaryValue, caseName, 5)
+  );
+
+  const improvementChecks = representativeCases.map((caseName) =>
+    evaluateImprovementCheck(baselineSummaryValue, featureSummaryValue, caseName, 5)
+  );
+
+  const asyncChecks = [
+    evaluateFeatureOnlyCompletionCheck(
+      'async-parser-midsize-4kb'
+    ),
+    evaluateFeatureOnlyCompletionCheck(
+      'async-parser-midsize-64kb'
+    ),
+    evaluateFeatureOnlyCompletionCheck(
+      'async-parser-mixed-256b'
+    ),
+  ];
+
+  const atLeastOneImprovement = {
+    caseName: 'representative-wrapper-improvement',
+    rule: 'at least one representative wrapper case improves by >= 5%',
+    pass: improvementChecks.some((check) => check.pass),
+    improvements: improvementChecks.map((check) => ({
+      caseName: check.caseName,
+      improvementPct: check.improvementPct,
+      pass: check.pass,
+    })),
+  };
+
+  return finalizeGateResult(
+    'wrapper',
+    'main',
+    [...regressionChecks, atLeastOneImprovement, ...asyncChecks],
+    baselineSummaryValue,
+    featureSummaryValue
+  );
+}
+
+function evaluateStressSuite(baselineSummaryValue, featureSummaryValue) {
+  const check = evaluateSignalCheck(
+    baselineSummaryValue,
+    featureSummaryValue,
+    'async-parser-single-chunk'
+  );
+
+  return {
+    suite: 'stress',
+    gateType: 'signal-only',
+    pass: true,
+    baselineLabel: baselineSummaryValue.label,
+    featureLabel: featureSummaryValue.label,
+    timestamp: new Date().toISOString(),
+    checks: [check],
+  };
+}
+
+function finalizeGateResult(suiteName, baselineLabel, checks, baselineSummaryValue, featureSummaryValue) {
+  return {
+    suite: suiteName,
+    gateType: `${baselineLabel}-vs-feature`,
+    pass: checks.every((check) => check.pass),
+    baselineLabel: baselineSummaryValue.label,
+    featureLabel: featureSummaryValue.label,
+    baselineHead: baselineSummaryValue.git?.head ?? null,
+    featureHead: featureSummaryValue.git?.head ?? null,
+    timestamp: new Date().toISOString(),
+    checks,
+  };
+}
+
+function evaluateImprovementCheck(baselineSummaryValue, featureSummaryValue, caseName, minImprovementPct) {
+  const baseline = getCaseSummary(baselineSummaryValue, caseName);
+  const feature = getCaseSummary(featureSummaryValue, caseName);
+  if (!baseline || !feature) {
+    return missingCaseCheck(caseName, `missing benchmark result for ${caseName}`);
+  }
+
+  const improvementPct = percentageDelta(baseline.meanMs, feature.meanMs);
+  return {
+    caseName,
+    rule: `improvement >= ${minImprovementPct}%`,
+    pass: improvementPct >= minImprovementPct,
+    baselineMeanMs: baseline.meanMs,
+    featureMeanMs: feature.meanMs,
+    improvementPct,
+  };
+}
+
+function evaluateMaxRegressionCheck(baselineSummaryValue, featureSummaryValue, caseName, maxRegressionPct) {
+  const baseline = getCaseSummary(baselineSummaryValue, caseName);
+  const feature = getCaseSummary(featureSummaryValue, caseName);
+  if (!baseline || !feature) {
+    return missingCaseCheck(caseName, `missing benchmark result for ${caseName}`);
+  }
+
+  const regressionPct = ((feature.meanMs - baseline.meanMs) / baseline.meanMs) * 100;
+  return {
+    caseName,
+    rule: `regression <= ${maxRegressionPct}%`,
+    pass: regressionPct <= maxRegressionPct,
+    baselineMeanMs: baseline.meanMs,
+    featureMeanMs: feature.meanMs,
+    regressionPct,
+  };
+}
+
+function evaluateRatioCheck(baselineSummaryValue, featureSummaryValue, caseName, maxRatio) {
+  const baseline = getCaseSummary(baselineSummaryValue, caseName);
+  const feature = getCaseSummary(featureSummaryValue, caseName);
+  if (!baseline || !feature) {
+    return missingCaseCheck(caseName, `missing benchmark result for ${caseName}`);
+  }
+
+  const ratio = feature.meanMs / baseline.meanMs;
+  const correctnessMatch = compareCorrectness(baseline, feature);
+  return {
+    caseName,
+    rule: `completed and ratio <= ${maxRatio}x`,
+    pass: !feature.timedOut && ratio <= maxRatio && correctnessMatch,
+    baselineMeanMs: baseline.meanMs,
+    featureMeanMs: feature.meanMs,
+    ratio,
+    featureTimedOut: feature.timedOut ?? false,
+    correctnessMatch,
+  };
+}
+
+function evaluateFeatureOnlyCompletionCheck(caseName) {
+  const feature = getCaseSummary(featureSummary, caseName);
+  if (!feature) {
+    return missingCaseCheck(caseName, `missing benchmark result for ${caseName}`);
+  }
+
+  return {
+    caseName,
+    rule: 'completed without timeout',
+    pass: !feature.timedOut,
+    featureTimedOut: feature.timedOut ?? false,
+    featureMeanMs: feature.meanMs ?? null,
+    featureChecksum: feature.correctness?.trace?.checksum ?? null,
+  };
+}
+
+function evaluateSignalCheck(baselineSummaryValue, featureSummaryValue, caseName) {
+  const baseline = getCaseSummary(baselineSummaryValue, caseName);
+  const feature = getCaseSummary(featureSummaryValue, caseName);
+  if (!baseline || !feature) {
+    return {
+      caseName,
+      status: 'missing',
+      pass: true,
+      note: 'signal only; missing result does not fail the suite',
+    };
+  }
+
+  return {
+    caseName,
+    status: 'signal',
+    pass: true,
+    baselineMeanMs: baseline.meanMs,
+    featureMeanMs: feature.meanMs,
+    ratio: feature.meanMs / baseline.meanMs,
+    baselineChecksum: baseline.correctness?.trace?.checksum ?? null,
+    featureChecksum: feature.correctness?.trace?.checksum ?? null,
+    featureTimedOut: feature.timedOut ?? false,
+  };
+}
+
+function getCaseSummary(summary, caseName) {
+  const result = summary.results?.find((entry) => entry.name === caseName);
+  if (!result?.caseSummary) {
+    return null;
+  }
+
+  return {
+    ...result.caseSummary,
+    timedOut: result.timedOut ?? false,
+  };
+}
+
+function compareCorrectness(baseline, feature) {
+  return baseline.correctness?.trace?.checksum === feature.correctness?.trace?.checksum;
+}
+
+function percentageDelta(baselineMeanMs, featureMeanMs) {
+  return ((baselineMeanMs - featureMeanMs) / baselineMeanMs) * 100;
+}
+
+function missingCaseCheck(caseName, reason) {
+  return {
+    caseName,
+    pass: false,
+    reason,
+  };
+}

--- a/scripts/parser-benchmark-case.mjs
+++ b/scripts/parser-benchmark-case.mjs
@@ -1,0 +1,175 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { performance } from 'node:perf_hooks';
+import { pathToFileURL } from 'node:url';
+
+const [, , repoRootArg, caseNameArg] = process.argv;
+
+if (!repoRootArg || !caseNameArg) {
+  console.error('Usage: node scripts/parser-benchmark-case.mjs <repoRoot> <caseName>');
+  process.exit(1);
+}
+
+const repoRoot = path.resolve(repoRootArg);
+const caseName = caseNameArg;
+const distCandidates = [
+  path.join(repoRoot, 'packages/stax-xml/dist/index.js'),
+  path.join(repoRoot, 'packages/stax-xml/dist/index.mjs'),
+];
+const sourceEntry = path.join(repoRoot, 'packages/stax-xml/src/index.ts');
+const distEntry = distCandidates.find((candidate) => existsSync(candidate));
+
+if (!distEntry && !existsSync(sourceEntry)) {
+  console.error(`Missing parser entrypoints: ${distCandidates.join(', ')} and ${sourceEntry}`);
+  process.exit(1);
+}
+
+const entrypoint = distEntry ?? sourceEntry;
+const {
+  StaxXmlCursor,
+  StaxXmlCursorSync,
+  StaxXmlParser,
+  StaxXmlParserSync,
+  XmlEventType,
+} = await import(pathToFileURL(entrypoint).href);
+
+const midsizeXml = readFileSync(path.join(repoRoot, 'packages/benchmark/assets/midsize.xml'), 'utf8');
+const syncConsumeXml = createSyncConsumeXml(20000);
+const attrHeavyXml = createAttributeHeavyXml(2500, 48);
+
+const cases = {
+  'sync-consume': {
+    iterations: 8,
+    run: async () => consumeSync(StaxXmlCursorSync, StaxXmlParserSync, XmlEventType, syncConsumeXml),
+  },
+  'sync-attr-heavy': {
+    iterations: 10,
+    run: async () => consumeSync(StaxXmlCursorSync, StaxXmlParserSync, XmlEventType, attrHeavyXml),
+  },
+  'async-consume-single-chunk': {
+    iterations: 6,
+    run: async () => consumeAsync(StaxXmlParser, XmlEventType, midsizeXml, midsizeXml.length),
+  },
+  'async-consume-64kb-chunk': {
+    iterations: 6,
+    run: async () => consumeAsync(StaxXmlParser, XmlEventType, midsizeXml, 64 * 1024),
+  },
+};
+
+const selected = cases[caseName];
+if (!selected) {
+  console.error(`Unknown case: ${caseName}`);
+  console.error(`Supported cases: ${Object.keys(cases).join(', ')}`);
+  process.exit(1);
+}
+
+await selected.run();
+
+const timings = [];
+let eventsProcessed = 0;
+for (let i = 0; i < selected.iterations; i++) {
+  maybeGc();
+  const startedAt = performance.now();
+  eventsProcessed = await selected.run();
+  timings.push(performance.now() - startedAt);
+}
+
+const summary = {
+  caseName,
+  repoRoot,
+  entrypoint,
+  iterations: selected.iterations,
+  eventsProcessed,
+  minMs: Math.min(...timings),
+  maxMs: Math.max(...timings),
+  meanMs: average(timings),
+  timingsMs: timings,
+};
+
+console.log(JSON.stringify(summary, null, 2));
+
+function maybeGc() {
+  if (typeof global.gc === 'function') {
+    global.gc();
+  }
+}
+
+function average(values) {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function createAttributeHeavyXml(itemCount, attributeCount) {
+  const items = [];
+  for (let index = 0; index < itemCount; index++) {
+    const attributes = [];
+    for (let attributeIndex = 0; attributeIndex < attributeCount; attributeIndex++) {
+      attributes.push(`a${attributeIndex}="value-${index}-${attributeIndex}"`);
+    }
+    items.push(`<item ${attributes.join(' ')} />`);
+  }
+  return `<root>${items.join('')}</root>`;
+}
+
+function createSyncConsumeXml(itemCount) {
+  const items = [];
+  for (let index = 0; index < itemCount; index++) {
+    items.push(`<item><id>${index}</id><value>value-${index}</value></item>`);
+  }
+  return `<root>${items.join('')}</root>`;
+}
+
+function consumeSync(CursorSync, ParserSync, EventType, xml) {
+  let eventsProcessed = 0;
+
+  if (typeof CursorSync === 'function') {
+    const cursor = new CursorSync(xml);
+    while (cursor.hasNext()) {
+      const tokenType = cursor.next();
+      eventsProcessed++;
+      if (tokenType === EventType.ERROR) {
+        throw new Error('Cursor emitted unexpected ERROR token.');
+      }
+    }
+    return eventsProcessed;
+  }
+
+  const parser = new ParserSync(xml);
+  for (const event of parser) {
+    eventsProcessed++;
+    if (event.type === EventType.ERROR) {
+      throw event.error;
+    }
+  }
+  return eventsProcessed;
+}
+
+async function consumeAsync(ParserAsync, EventType, xml, chunkSize) {
+  let eventsProcessed = 0;
+  const parser = new ParserAsync(createChunkedStream(xml, chunkSize));
+  for await (const event of parser) {
+    eventsProcessed++;
+    if (event.type === EventType.ERROR) {
+      throw event.error;
+    }
+  }
+  return eventsProcessed;
+}
+
+function createChunkedStream(xml, chunkSize) {
+  const bytes = new TextEncoder().encode(xml);
+  let offset = 0;
+
+  return new ReadableStream({
+    pull(controller) {
+      if (offset >= bytes.length) {
+        controller.close();
+        return;
+      }
+
+      const nextOffset = Math.min(offset + chunkSize, bytes.length);
+      controller.enqueue(bytes.slice(offset, nextOffset));
+      offset = nextOffset;
+    }
+  });
+}

--- a/scripts/parser-benchmark-case.mjs
+++ b/scripts/parser-benchmark-case.mjs
@@ -1,93 +1,201 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { performance } from 'node:perf_hooks';
 import { pathToFileURL } from 'node:url';
+import { getGitMetadata, resolveBuiltDistEntrypoint } from './compare-runner-lib.mjs';
 
-const [, , repoRootArg, caseNameArg] = process.argv;
+const [, , repoRootArg, suiteArg, caseNameArg, comparisonBaselineArg = 'none'] = process.argv;
 
-if (!repoRootArg || !caseNameArg) {
-  console.error('Usage: node scripts/parser-benchmark-case.mjs <repoRoot> <caseName>');
+if (!repoRootArg || !suiteArg || !caseNameArg) {
+  console.error(
+    'Usage: node scripts/parser-benchmark-case.mjs <repoRoot> <suite> <caseName> [comparisonBaseline]'
+  );
   process.exit(1);
 }
 
 const repoRoot = path.resolve(repoRootArg);
+const suite = suiteArg;
 const caseName = caseNameArg;
-const distCandidates = [
-  path.join(repoRoot, 'packages/stax-xml/dist/index.js'),
-  path.join(repoRoot, 'packages/stax-xml/dist/index.mjs'),
-];
-const sourceEntry = path.join(repoRoot, 'packages/stax-xml/src/index.ts');
-const distEntry = distCandidates.find((candidate) => existsSync(candidate));
+const comparisonBaseline = comparisonBaselineArg;
+const timestamp = new Date().toISOString();
+const entrypoint = resolveBuiltDistEntrypoint(repoRoot);
+const api = await import(pathToFileURL(entrypoint).href);
+const git = await getGitMetadata(repoRoot);
 
-if (!distEntry && !existsSync(sourceEntry)) {
-  console.error(`Missing parser entrypoints: ${distCandidates.join(', ')} and ${sourceEntry}`);
-  process.exit(1);
-}
+const cases = getCaseDefinitions(repoRoot);
+const suiteCases = cases[suite];
+const selected = suiteCases?.[caseName];
 
-const entrypoint = distEntry ?? sourceEntry;
-const {
-  StaxXmlCursor,
-  StaxXmlCursorSync,
-  StaxXmlParser,
-  StaxXmlParserSync,
-  XmlEventType,
-} = await import(pathToFileURL(entrypoint).href);
-
-const midsizeXml = readFileSync(path.join(repoRoot, 'packages/benchmark/assets/midsize.xml'), 'utf8');
-const syncConsumeXml = createSyncConsumeXml(20000);
-const attrHeavyXml = createAttributeHeavyXml(2500, 48);
-
-const cases = {
-  'sync-consume': {
-    iterations: 8,
-    run: async () => consumeSync(StaxXmlCursorSync, StaxXmlParserSync, XmlEventType, syncConsumeXml),
-  },
-  'sync-attr-heavy': {
-    iterations: 10,
-    run: async () => consumeSync(StaxXmlCursorSync, StaxXmlParserSync, XmlEventType, attrHeavyXml),
-  },
-  'async-consume-single-chunk': {
-    iterations: 6,
-    run: async () => consumeAsync(StaxXmlParser, XmlEventType, midsizeXml, midsizeXml.length),
-  },
-  'async-consume-64kb-chunk': {
-    iterations: 6,
-    run: async () => consumeAsync(StaxXmlParser, XmlEventType, midsizeXml, 64 * 1024),
-  },
-};
-
-const selected = cases[caseName];
 if (!selected) {
-  console.error(`Unknown case: ${caseName}`);
-  console.error(`Supported cases: ${Object.keys(cases).join(', ')}`);
+  console.error(`Unknown suite/case combination: ${suite}/${caseName}`);
+  console.error(
+    `Supported cases: ${Object.entries(cases)
+      .flatMap(([suiteName, suiteEntries]) => Object.keys(suiteEntries).map((name) => `${suiteName}/${name}`))
+      .join(', ')}`
+  );
   process.exit(1);
 }
 
-await selected.run();
+const fixture = selected.load();
+const correctness = await selected.verify(api, fixture);
+await selected.measure(api, fixture);
 
 const timings = [];
-let eventsProcessed = 0;
-for (let i = 0; i < selected.iterations; i++) {
+let unitsProcessed = 0;
+for (let iteration = 0; iteration < selected.iterations; iteration++) {
   maybeGc();
   const startedAt = performance.now();
-  eventsProcessed = await selected.run();
+  unitsProcessed = await selected.measure(api, fixture);
   timings.push(performance.now() - startedAt);
 }
 
 const summary = {
-  caseName,
   repoRoot,
+  git,
+  comparisonBaseline,
+  suite,
+  caseName,
+  label: selected.label,
   entrypoint,
+  timestamp,
+  entrySurface: selected.entrySurface,
+  fixture: fixture.metadata,
   iterations: selected.iterations,
-  eventsProcessed,
+  unitsProcessed,
   minMs: Math.min(...timings),
   maxMs: Math.max(...timings),
   meanMs: average(timings),
   timingsMs: timings,
+  correctness,
+  completed: true,
 };
 
 console.log(JSON.stringify(summary, null, 2));
+
+function getCaseDefinitions(root) {
+  return {
+    cursor: {
+      'sync-cursor-consume': {
+        label: 'synthetic token-dense XML',
+        entrySurface: 'cursor',
+        iterations: 8,
+        load: () => ({
+          xml: createTokenDenseXml(20_000),
+          metadata: {
+            type: 'synthetic',
+            description: 'Token-dense XML with repeated item/id/value triplets',
+          },
+        }),
+        verify: ({ StaxXmlCursorSync, XmlEventType }, fixture) =>
+          verifySyncCursor(StaxXmlCursorSync, XmlEventType, fixture.xml),
+        measure: ({ StaxXmlCursorSync, XmlEventType }, fixture) =>
+          measureSyncCursor(StaxXmlCursorSync, XmlEventType, fixture.xml),
+      },
+      'sync-cursor-attr-unused': {
+        label: 'synthetic attribute-dense XML without attribute access',
+        entrySurface: 'cursor',
+        iterations: 10,
+        load: () => ({
+          xml: createAttributeDenseXml(2_500, 48),
+          metadata: {
+            type: 'synthetic',
+            description: 'Attribute-dense XML without calling cursor attribute accessors',
+          },
+        }),
+        verify: ({ StaxXmlCursorSync, XmlEventType }, fixture) =>
+          verifySyncCursor(StaxXmlCursorSync, XmlEventType, fixture.xml),
+        measure: ({ StaxXmlCursorSync, XmlEventType }, fixture) =>
+          measureSyncCursor(StaxXmlCursorSync, XmlEventType, fixture.xml),
+      },
+      'async-cursor-midsize-4kb': {
+        label: 'midsize.xml via async cursor with 4KB chunks',
+        entrySurface: 'cursor',
+        iterations: 6,
+        load: () => loadXmlFixture(root, 'midsize.xml', 4 * 1024),
+        verify: ({ StaxXmlCursor, XmlEventType }, fixture) =>
+          verifyAsyncCursor(StaxXmlCursor, XmlEventType, fixture.xml, fixture.chunkSize),
+        measure: ({ StaxXmlCursor, XmlEventType }, fixture) =>
+          measureAsyncCursor(StaxXmlCursor, XmlEventType, fixture.xml, fixture.chunkSize),
+      },
+      'async-cursor-midsize-64kb': {
+        label: 'midsize.xml via async cursor with 64KB chunks',
+        entrySurface: 'cursor',
+        iterations: 6,
+        load: () => loadXmlFixture(root, 'midsize.xml', 64 * 1024),
+        verify: ({ StaxXmlCursor, XmlEventType }, fixture) =>
+          verifyAsyncCursor(StaxXmlCursor, XmlEventType, fixture.xml, fixture.chunkSize),
+        measure: ({ StaxXmlCursor, XmlEventType }, fixture) =>
+          measureAsyncCursor(StaxXmlCursor, XmlEventType, fixture.xml, fixture.chunkSize),
+      },
+    },
+    wrapper: {
+      'sync-parser-books': {
+        label: 'books.xml via public sync parser',
+        entrySurface: 'wrapper',
+        iterations: 12,
+        load: () => loadXmlFixture(root, 'books.xml'),
+        verify: ({ StaxXmlParserSync, XmlEventType }, fixture) =>
+          verifySyncParser(StaxXmlParserSync, XmlEventType, fixture.xml),
+        measure: ({ StaxXmlParserSync, XmlEventType }, fixture) =>
+          measureSyncParser(StaxXmlParserSync, XmlEventType, fixture.xml),
+      },
+      'sync-parser-complex': {
+        label: 'complex.xml via public sync parser',
+        entrySurface: 'wrapper',
+        iterations: 12,
+        load: () => loadXmlFixture(root, 'complex.xml'),
+        verify: ({ StaxXmlParserSync, XmlEventType }, fixture) =>
+          verifySyncParser(StaxXmlParserSync, XmlEventType, fixture.xml),
+        measure: ({ StaxXmlParserSync, XmlEventType }, fixture) =>
+          measureSyncParser(StaxXmlParserSync, XmlEventType, fixture.xml),
+      },
+      'async-parser-midsize-4kb': {
+        label: 'midsize.xml via public async parser with 4KB chunks',
+        entrySurface: 'wrapper',
+        iterations: 6,
+        load: () => loadXmlFixture(root, 'midsize.xml', 4 * 1024),
+        verify: ({ StaxXmlParser, XmlEventType }, fixture) =>
+          verifyAsyncParser(StaxXmlParser, XmlEventType, fixture.xml, fixture.chunkSize),
+        measure: ({ StaxXmlParser, XmlEventType }, fixture) =>
+          measureAsyncParser(StaxXmlParser, XmlEventType, fixture.xml, fixture.chunkSize),
+      },
+      'async-parser-midsize-64kb': {
+        label: 'midsize.xml via public async parser with 64KB chunks',
+        entrySurface: 'wrapper',
+        iterations: 6,
+        load: () => loadXmlFixture(root, 'midsize.xml', 64 * 1024),
+        verify: ({ StaxXmlParser, XmlEventType }, fixture) =>
+          verifyAsyncParser(StaxXmlParser, XmlEventType, fixture.xml, fixture.chunkSize),
+        measure: ({ StaxXmlParser, XmlEventType }, fixture) =>
+          measureAsyncParser(StaxXmlParser, XmlEventType, fixture.xml, fixture.chunkSize),
+      },
+      'async-parser-mixed-256b': {
+        label: 'mixed.xml via public async parser with 256B chunks',
+        entrySurface: 'wrapper',
+        iterations: 8,
+        load: () => loadXmlFixture(root, 'mixed.xml', 256),
+        verify: ({ StaxXmlParser, XmlEventType }, fixture) =>
+          verifyAsyncParser(StaxXmlParser, XmlEventType, fixture.xml, fixture.chunkSize),
+        measure: ({ StaxXmlParser, XmlEventType }, fixture) =>
+          measureAsyncParser(StaxXmlParser, XmlEventType, fixture.xml, fixture.chunkSize),
+      },
+    },
+    stress: {
+      'async-parser-single-chunk': {
+        label: 'midsize.xml via public async parser in one chunk',
+        entrySurface: 'wrapper',
+        iterations: 4,
+        load: () => loadXmlFixture(root, 'midsize.xml', 'single-chunk'),
+        verify: ({ StaxXmlParser, XmlEventType }, fixture) =>
+          verifyAsyncParser(StaxXmlParser, XmlEventType, fixture.xml, fixture.chunkSize),
+        measure: ({ StaxXmlParser, XmlEventType }, fixture) =>
+          measureAsyncParser(StaxXmlParser, XmlEventType, fixture.xml, fixture.chunkSize),
+      },
+    },
+  };
+}
 
 function maybeGc() {
   if (typeof global.gc === 'function') {
@@ -99,7 +207,30 @@ function average(values) {
   return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
 
-function createAttributeHeavyXml(itemCount, attributeCount) {
+function loadXmlFixture(repoRoot, assetName, chunkSize) {
+  const xml = readFileSync(path.join(repoRoot, 'packages/benchmark/assets', assetName), 'utf8');
+  return {
+    xml,
+    chunkSize,
+    metadata: {
+      type: 'asset',
+      asset: assetName,
+      chunkSize: describeChunkSize(chunkSize, xml),
+    },
+  };
+}
+
+function describeChunkSize(chunkSize, xml) {
+  if (chunkSize === undefined) {
+    return null;
+  }
+  if (chunkSize === 'single-chunk') {
+    return new TextEncoder().encode(xml).length;
+  }
+  return chunkSize;
+}
+
+function createAttributeDenseXml(itemCount, attributeCount) {
   const items = [];
   for (let index = 0; index < itemCount; index++) {
     const attributes = [];
@@ -111,53 +242,249 @@ function createAttributeHeavyXml(itemCount, attributeCount) {
   return `<root>${items.join('')}</root>`;
 }
 
-function createSyncConsumeXml(itemCount) {
+function createTokenDenseXml(itemCount) {
   const items = [];
   for (let index = 0; index < itemCount; index++) {
-    items.push(`<item><id>${index}</id><value>value-${index}</value></item>`);
+    items.push(`<item><id>${index}</id><value>value-${index}</value><flag/></item>`);
   }
   return `<root>${items.join('')}</root>`;
 }
 
-function consumeSync(CursorSync, ParserSync, EventType, xml) {
-  let eventsProcessed = 0;
-
-  if (typeof CursorSync === 'function') {
-    const cursor = new CursorSync(xml);
-    while (cursor.hasNext()) {
-      const tokenType = cursor.next();
-      eventsProcessed++;
-      if (tokenType === EventType.ERROR) {
-        throw new Error('Cursor emitted unexpected ERROR token.');
-      }
-    }
-    return eventsProcessed;
-  }
-
-  const parser = new ParserSync(xml);
-  for (const event of parser) {
-    eventsProcessed++;
-    if (event.type === EventType.ERROR) {
-      throw event.error;
+function measureSyncCursor(CursorSync, EventType, xml) {
+  assertExport(CursorSync, 'StaxXmlCursorSync');
+  let unitsProcessed = 0;
+  const cursor = new CursorSync(xml);
+  while (cursor.hasNext()) {
+    const tokenType = cursor.next();
+    unitsProcessed++;
+    if (tokenType === EventType.ERROR) {
+      throw new Error('Cursor emitted unexpected ERROR token.');
     }
   }
-  return eventsProcessed;
+  return unitsProcessed;
 }
 
-async function consumeAsync(ParserAsync, EventType, xml, chunkSize) {
-  let eventsProcessed = 0;
-  const parser = new ParserAsync(createChunkedStream(xml, chunkSize));
-  for await (const event of parser) {
-    eventsProcessed++;
+async function measureAsyncCursor(CursorAsync, EventType, xml, chunkSize) {
+  assertExport(CursorAsync, 'StaxXmlCursor');
+  let unitsProcessed = 0;
+  const cursor = new CursorAsync(createChunkedStream(xml, chunkSize));
+  while (cursor.hasNext()) {
+    const tokenType = await cursor.next();
+    unitsProcessed++;
+    if (tokenType === EventType.ERROR) {
+      throw new Error('Cursor emitted unexpected ERROR token.');
+    }
+  }
+  return unitsProcessed;
+}
+
+function measureSyncParser(ParserSync, EventType, xml) {
+  assertExport(ParserSync, 'StaxXmlParserSync');
+  let unitsProcessed = 0;
+  const parser = new ParserSync(xml);
+  for (const event of parser) {
+    unitsProcessed++;
     if (event.type === EventType.ERROR) {
       throw event.error;
     }
   }
-  return eventsProcessed;
+  return unitsProcessed;
+}
+
+async function measureAsyncParser(ParserAsync, EventType, xml, chunkSize) {
+  assertExport(ParserAsync, 'StaxXmlParser');
+  let unitsProcessed = 0;
+  const parser = new ParserAsync(createChunkedStream(xml, chunkSize));
+  for await (const event of parser) {
+    unitsProcessed++;
+    if (event.type === EventType.ERROR) {
+      throw event.error;
+    }
+  }
+  return unitsProcessed;
+}
+
+function verifySyncCursor(CursorSync, EventType, xml) {
+  assertExport(CursorSync, 'StaxXmlCursorSync');
+  const trace = createTraceSummary();
+  let unitsProcessed = 0;
+  const cursor = new CursorSync(xml);
+  while (cursor.hasNext()) {
+    const tokenType = cursor.next();
+    unitsProcessed++;
+    if (tokenType === EventType.ERROR) {
+      throw new Error('Cursor emitted unexpected ERROR token.');
+    }
+    trace.push(normalizeCursorToken(cursor, tokenType, EventType));
+  }
+  return {
+    unitsProcessed,
+    trace: trace.finish(),
+  };
+}
+
+async function verifyAsyncCursor(CursorAsync, EventType, xml, chunkSize) {
+  assertExport(CursorAsync, 'StaxXmlCursor');
+  const trace = createTraceSummary();
+  let unitsProcessed = 0;
+  const cursor = new CursorAsync(createChunkedStream(xml, chunkSize));
+  while (cursor.hasNext()) {
+    const tokenType = await cursor.next();
+    unitsProcessed++;
+    if (tokenType === EventType.ERROR) {
+      throw new Error('Cursor emitted unexpected ERROR token.');
+    }
+    trace.push(normalizeCursorToken(cursor, tokenType, EventType));
+  }
+  return {
+    unitsProcessed,
+    trace: trace.finish(),
+  };
+}
+
+function verifySyncParser(ParserSync, EventType, xml) {
+  assertExport(ParserSync, 'StaxXmlParserSync');
+  const trace = createTraceSummary();
+  let unitsProcessed = 0;
+  const parser = new ParserSync(xml);
+  for (const event of parser) {
+    unitsProcessed++;
+    if (event.type === EventType.ERROR) {
+      throw event.error;
+    }
+    trace.push(normalizeEvent(event));
+  }
+  return {
+    unitsProcessed,
+    trace: trace.finish(),
+  };
+}
+
+async function verifyAsyncParser(ParserAsync, EventType, xml, chunkSize) {
+  assertExport(ParserAsync, 'StaxXmlParser');
+  const trace = createTraceSummary();
+  let unitsProcessed = 0;
+  const parser = new ParserAsync(createChunkedStream(xml, chunkSize));
+  for await (const event of parser) {
+    unitsProcessed++;
+    if (event.type === EventType.ERROR) {
+      throw event.error;
+    }
+    trace.push(normalizeEvent(event));
+  }
+  return {
+    unitsProcessed,
+    trace: trace.finish(),
+  };
+}
+
+function normalizeCursorToken(cursor, tokenType, EventType) {
+  const normalized = {
+    type: tokenType,
+    name: cursor.name,
+    localName: cursor.localName,
+    prefix: cursor.prefix,
+    uri: cursor.uri,
+    text: tokenType === EventType.CHARACTERS || tokenType === EventType.CDATA
+      ? cursor.getText()
+      : undefined,
+  };
+  return stripUndefined(normalized);
+}
+
+function normalizeEvent(event) {
+  const normalized = {
+    type: event.type,
+    name: 'name' in event ? event.name : undefined,
+    localName: 'localName' in event ? event.localName : undefined,
+    prefix: 'prefix' in event ? event.prefix : undefined,
+    uri: 'uri' in event ? event.uri : undefined,
+    text: 'value' in event ? event.value : undefined,
+    attributes: 'attributes' in event ? sortRecord(event.attributes) : undefined,
+    attributesWithPrefix: 'attributesWithPrefix' in event
+      ? normalizeAttributesWithPrefix(event.attributesWithPrefix)
+      : undefined,
+  };
+  return stripUndefined(normalized);
+}
+
+function createTraceSummary() {
+  const countsByType = {};
+  const hash = createHash('sha256');
+  let totalRecords = 0;
+  let firstStartElement = null;
+  let lastEndElement = null;
+
+  return {
+    push(record) {
+      totalRecords++;
+      countsByType[record.type] = (countsByType[record.type] ?? 0) + 1;
+      if (!firstStartElement && record.type === 'START_ELEMENT') {
+        firstStartElement = record.name ?? record.localName ?? null;
+      }
+      if (record.type === 'END_ELEMENT') {
+        lastEndElement = record.name ?? record.localName ?? null;
+      }
+      hash.update(`${JSON.stringify(record)}\n`);
+    },
+    finish() {
+      return {
+        totalRecords,
+        countsByType,
+        firstStartElement,
+        lastEndElement,
+        checksum: hash.digest('hex'),
+      };
+    },
+  };
+}
+
+function normalizeAttributesWithPrefix(value) {
+  if (!value) {
+    return undefined;
+  }
+
+  return Object.entries(value)
+    .map(([key, info]) => normalizeAttributeEntry(key, info))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function normalizeAttributeEntry(key, info) {
+  const localName = info.localName ?? key;
+  const name = info.prefix
+    ? `${info.prefix}:${localName}`
+    : localName;
+
+  return stripUndefined({
+    name,
+    localName,
+    prefix: info.prefix,
+    uri: info.uri,
+    value: info.value,
+  });
+}
+
+function sortRecord(value) {
+  if (!value) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).sort(([left], [right]) => left.localeCompare(right))
+  );
+}
+
+function stripUndefined(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  );
 }
 
 function createChunkedStream(xml, chunkSize) {
   const bytes = new TextEncoder().encode(xml);
+  const actualChunkSize = chunkSize === 'single-chunk'
+    ? bytes.length
+    : chunkSize;
   let offset = 0;
 
   return new ReadableStream({
@@ -167,9 +494,15 @@ function createChunkedStream(xml, chunkSize) {
         return;
       }
 
-      const nextOffset = Math.min(offset + chunkSize, bytes.length);
+      const nextOffset = Math.min(offset + actualChunkSize, bytes.length);
       controller.enqueue(bytes.slice(offset, nextOffset));
       offset = nextOffset;
     }
   });
+}
+
+function assertExport(value, exportName) {
+  if (typeof value !== 'function') {
+    throw new Error(`Built dist is missing required export: ${exportName}`);
+  }
 }

--- a/scripts/run-benchmark.mjs
+++ b/scripts/run-benchmark.mjs
@@ -2,46 +2,40 @@ import path from 'node:path';
 import process from 'node:process';
 import {
   ensureDir,
+  getWorktreeList,
   getGitMetadata,
   getOutputRoot,
+  resolveBuiltDistEntrypoint,
   runLoggedCommand,
   usage,
   writeJson,
 } from './compare-runner-lib.mjs';
 
-const [, , repoRootArg, label, suiteArg = 'all'] = process.argv;
+const [, , repoRootArg, label, suiteArg = 'all', comparisonBaselineArg = 'none'] = process.argv;
 
 if (!repoRootArg || !label) {
-  usage('Usage: node scripts/run-benchmark.mjs <repoRoot> <label> [suite]');
+  usage('Usage: node scripts/run-benchmark.mjs <repoRoot> <label> [suite] [comparisonBaseline]');
   process.exit(1);
 }
 
 const repoRoot = path.resolve(repoRootArg);
 const suite = suiteArg;
+const comparisonBaseline = comparisonBaselineArg;
 const benchmarkOutputDir = await ensureDir(path.join(getOutputRoot(label), 'benchmarks'));
 const git = await getGitMetadata(repoRoot);
+const worktrees = await getWorktreeList(repoRoot);
+const entrypoint = resolveBuiltDistEntrypoint(repoRoot);
 const scriptPath = path.join(path.dirname(new URL(import.meta.url).pathname), 'parser-benchmark-case.mjs');
-const tsxPath = path.join(path.dirname(path.dirname(scriptPath)), 'node_modules', 'tsx', 'dist', 'cli.mjs');
 
 const suiteCommands = {
   all: [
-    { name: 'sync-consume', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'sync-consume'] },
-    { name: 'sync-attr-heavy', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'sync-attr-heavy'] },
-    { name: 'async-consume-single-chunk', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'async-consume-single-chunk'] },
-    { name: 'async-consume-64kb-chunk', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'async-consume-64kb-chunk'] },
+    ...buildSuiteCommands(label, 'cursor', repoRoot, scriptPath, comparisonBaseline),
+    ...buildSuiteCommands(label, 'wrapper', repoRoot, scriptPath, comparisonBaseline),
+    ...buildSuiteCommands(label, 'stress', repoRoot, scriptPath, comparisonBaseline),
   ],
-  'sync-consume': [
-    { name: 'sync-consume', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'sync-consume'] },
-  ],
-  'sync-attr-heavy': [
-    { name: 'sync-attr-heavy', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'sync-attr-heavy'] },
-  ],
-  'async-consume-single-chunk': [
-    { name: 'async-consume-single-chunk', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'async-consume-single-chunk'] },
-  ],
-  'async-consume-64kb-chunk': [
-    { name: 'async-consume-64kb-chunk', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'async-consume-64kb-chunk'] },
-  ],
+  cursor: buildSuiteCommands(label, 'cursor', repoRoot, scriptPath, comparisonBaseline),
+  wrapper: buildSuiteCommands(label, 'wrapper', repoRoot, scriptPath, comparisonBaseline),
+  stress: buildSuiteCommands(label, 'stress', repoRoot, scriptPath, comparisonBaseline),
 };
 
 const commands = suiteCommands[suite];
@@ -61,10 +55,15 @@ for (const step of commands) {
     args: step.args,
     cwd: repoRoot,
     logPath,
+    timeoutMs: step.timeoutMs,
   });
+  const caseSummary = parseCaseSummary(result.stdout);
   results.push({
     name: step.name,
+    suite: step.suite,
     command: [step.command, ...step.args],
+    timeoutMs: step.timeoutMs,
+    caseSummary,
     ...result,
   });
 
@@ -77,13 +76,72 @@ for (const step of commands) {
 const summaryPath = path.join(benchmarkOutputDir, `${suite}.json`);
 await writeJson(summaryPath, {
   label,
+  comparisonBaseline,
   suite,
   repoRoot,
   git,
-  generatedAt: new Date().toISOString(),
+  entrypoint,
+  timestamp: new Date().toISOString(),
+  worktrees,
   results,
 });
 
 if (failed) {
   process.exit(1);
+}
+
+function buildSuiteCommands(labelValue, suiteName, repoRootValue, scriptPathValue, baselineValue) {
+  const caseNamesBySuite = {
+    cursor: [
+      'sync-cursor-consume',
+      'sync-cursor-attr-unused',
+      'async-cursor-midsize-4kb',
+      'async-cursor-midsize-64kb',
+    ],
+    wrapper: [
+      'sync-parser-books',
+      'sync-parser-complex',
+      ...(labelValue === 'main' ? [] : [
+        'async-parser-midsize-4kb',
+        'async-parser-midsize-64kb',
+        'async-parser-mixed-256b',
+      ]),
+    ],
+    stress: [
+      'async-parser-single-chunk',
+    ],
+  };
+
+  const timeoutByCase = {
+    'sync-cursor-consume': 60_000,
+    'sync-cursor-attr-unused': 60_000,
+    'async-cursor-midsize-4kb': 120_000,
+    'async-cursor-midsize-64kb': 120_000,
+    'sync-parser-books': 60_000,
+    'sync-parser-complex': 60_000,
+    'async-parser-midsize-4kb': 120_000,
+    'async-parser-midsize-64kb': 120_000,
+    'async-parser-mixed-256b': 120_000,
+    'async-parser-single-chunk': 120_000,
+  };
+
+  return caseNamesBySuite[suiteName].map((caseName) => ({
+    name: caseName,
+    suite: suiteName,
+    timeoutMs: timeoutByCase[caseName],
+    command: 'node',
+    args: ['--expose-gc', scriptPathValue, repoRootValue, suiteName, caseName, baselineValue],
+  }));
+}
+
+function parseCaseSummary(stdout) {
+  if (!stdout) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    return null;
+  }
 }

--- a/scripts/run-benchmark.mjs
+++ b/scripts/run-benchmark.mjs
@@ -1,0 +1,89 @@
+import path from 'node:path';
+import process from 'node:process';
+import {
+  ensureDir,
+  getGitMetadata,
+  getOutputRoot,
+  runLoggedCommand,
+  usage,
+  writeJson,
+} from './compare-runner-lib.mjs';
+
+const [, , repoRootArg, label, suiteArg = 'all'] = process.argv;
+
+if (!repoRootArg || !label) {
+  usage('Usage: node scripts/run-benchmark.mjs <repoRoot> <label> [suite]');
+  process.exit(1);
+}
+
+const repoRoot = path.resolve(repoRootArg);
+const suite = suiteArg;
+const benchmarkOutputDir = await ensureDir(path.join(getOutputRoot(label), 'benchmarks'));
+const git = await getGitMetadata(repoRoot);
+const scriptPath = path.join(path.dirname(new URL(import.meta.url).pathname), 'parser-benchmark-case.mjs');
+const tsxPath = path.join(path.dirname(path.dirname(scriptPath)), 'node_modules', 'tsx', 'dist', 'cli.mjs');
+
+const suiteCommands = {
+  all: [
+    { name: 'sync-consume', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'sync-consume'] },
+    { name: 'sync-attr-heavy', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'sync-attr-heavy'] },
+    { name: 'async-consume-single-chunk', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'async-consume-single-chunk'] },
+    { name: 'async-consume-64kb-chunk', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'async-consume-64kb-chunk'] },
+  ],
+  'sync-consume': [
+    { name: 'sync-consume', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'sync-consume'] },
+  ],
+  'sync-attr-heavy': [
+    { name: 'sync-attr-heavy', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'sync-attr-heavy'] },
+  ],
+  'async-consume-single-chunk': [
+    { name: 'async-consume-single-chunk', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'async-consume-single-chunk'] },
+  ],
+  'async-consume-64kb-chunk': [
+    { name: 'async-consume-64kb-chunk', command: 'node', args: ['--expose-gc', tsxPath, scriptPath, repoRoot, 'async-consume-64kb-chunk'] },
+  ],
+};
+
+const commands = suiteCommands[suite];
+if (!commands) {
+  console.error(`Unknown suite: ${suite}`);
+  console.error(`Supported suites: ${Object.keys(suiteCommands).join(', ')}`);
+  process.exit(1);
+}
+
+const results = [];
+let failed = false;
+
+for (const step of commands) {
+  const logPath = path.join(benchmarkOutputDir, `${step.name}.log`);
+  const result = await runLoggedCommand({
+    command: step.command,
+    args: step.args,
+    cwd: repoRoot,
+    logPath,
+  });
+  results.push({
+    name: step.name,
+    command: [step.command, ...step.args],
+    ...result,
+  });
+
+  if (result.exitCode !== 0) {
+    failed = true;
+    break;
+  }
+}
+
+const summaryPath = path.join(benchmarkOutputDir, `${suite}.json`);
+await writeJson(summaryPath, {
+  label,
+  suite,
+  repoRoot,
+  git,
+  generatedAt: new Date().toISOString(),
+  results,
+});
+
+if (failed) {
+  process.exit(1);
+}

--- a/scripts/run-node-cpu-prof.mjs
+++ b/scripts/run-node-cpu-prof.mjs
@@ -2,9 +2,11 @@ import path from 'node:path';
 import process from 'node:process';
 import {
   ensureDir,
+  getWorktreeList,
   getGitMetadata,
   getOutputRoot,
   listCpuProfiles,
+  resolveBuiltDistEntrypoint,
   runLoggedCommand,
   usage,
   writeJson,
@@ -14,10 +16,12 @@ const separatorIndex = process.argv.indexOf('--');
 const headArgs = separatorIndex === -1 ? process.argv.slice(2) : process.argv.slice(2, separatorIndex);
 const tailArgs = separatorIndex === -1 ? [] : process.argv.slice(separatorIndex + 1);
 
-const [repoRootArg, label, profileName, entryScriptArg] = headArgs;
+const [repoRootArg, label, suite, comparisonBaseline, profileName, entryScriptArg] = headArgs;
 
-if (!repoRootArg || !label || !profileName || !entryScriptArg) {
-  usage('Usage: node scripts/run-node-cpu-prof.mjs <repoRoot> <label> <profileName> <entryScript> [-- <args...>]');
+if (!repoRootArg || !label || !suite || !comparisonBaseline || !profileName || !entryScriptArg) {
+  usage(
+    'Usage: node scripts/run-node-cpu-prof.mjs <repoRoot> <label> <suite> <comparisonBaseline> <profileName> <entryScript> [-- <args...>]'
+  );
   process.exit(1);
 }
 
@@ -28,6 +32,8 @@ const entryScript = path.isAbsolute(entryScriptArg)
 const outputDir = await ensureDir(path.join(getOutputRoot(label), 'profiles', profileName));
 const logPath = path.join(outputDir, `${profileName}.log`);
 const git = await getGitMetadata(repoRoot);
+const worktrees = await getWorktreeList(repoRoot);
+const distEntrypoint = resolveBuiltDistEntrypoint(repoRoot);
 
 const result = await runLoggedCommand({
   command: 'node',
@@ -40,12 +46,16 @@ const profiles = await listCpuProfiles(outputDir);
 const summaryPath = path.join(outputDir, `${profileName}.json`);
 await writeJson(summaryPath, {
   label,
+  suite,
+  comparisonBaseline,
   profileName,
   repoRoot,
-  entryScript,
+  entrypoint: entryScript,
+  distEntrypoint,
   args: tailArgs,
   git,
-  generatedAt: new Date().toISOString(),
+  timestamp: new Date().toISOString(),
+  worktrees,
   result,
   profiles,
 });

--- a/scripts/run-node-cpu-prof.mjs
+++ b/scripts/run-node-cpu-prof.mjs
@@ -1,0 +1,55 @@
+import path from 'node:path';
+import process from 'node:process';
+import {
+  ensureDir,
+  getGitMetadata,
+  getOutputRoot,
+  listCpuProfiles,
+  runLoggedCommand,
+  usage,
+  writeJson,
+} from './compare-runner-lib.mjs';
+
+const separatorIndex = process.argv.indexOf('--');
+const headArgs = separatorIndex === -1 ? process.argv.slice(2) : process.argv.slice(2, separatorIndex);
+const tailArgs = separatorIndex === -1 ? [] : process.argv.slice(separatorIndex + 1);
+
+const [repoRootArg, label, profileName, entryScriptArg] = headArgs;
+
+if (!repoRootArg || !label || !profileName || !entryScriptArg) {
+  usage('Usage: node scripts/run-node-cpu-prof.mjs <repoRoot> <label> <profileName> <entryScript> [-- <args...>]');
+  process.exit(1);
+}
+
+const repoRoot = path.resolve(repoRootArg);
+const entryScript = path.isAbsolute(entryScriptArg)
+  ? entryScriptArg
+  : path.join(repoRoot, entryScriptArg);
+const outputDir = await ensureDir(path.join(getOutputRoot(label), 'profiles', profileName));
+const logPath = path.join(outputDir, `${profileName}.log`);
+const git = await getGitMetadata(repoRoot);
+
+const result = await runLoggedCommand({
+  command: 'node',
+  args: ['--cpu-prof', '--cpu-prof-dir', outputDir, entryScript, ...tailArgs],
+  cwd: repoRoot,
+  logPath,
+});
+
+const profiles = await listCpuProfiles(outputDir);
+const summaryPath = path.join(outputDir, `${profileName}.json`);
+await writeJson(summaryPath, {
+  label,
+  profileName,
+  repoRoot,
+  entryScript,
+  args: tailArgs,
+  git,
+  generatedAt: new Date().toISOString(),
+  result,
+  profiles,
+});
+
+if (result.exitCode !== 0) {
+  process.exit(1);
+}

--- a/scripts/verify-core-parser-baselines.mjs
+++ b/scripts/verify-core-parser-baselines.mjs
@@ -1,0 +1,108 @@
+import path from 'node:path';
+import process from 'node:process';
+import {
+  getGitMetadata,
+  getGitStatusSummary,
+  getWorktreeList,
+  resolveBuiltDistEntrypoint,
+} from './compare-runner-lib.mjs';
+
+const args = process.argv.slice(2);
+const positional = [];
+const expectations = {
+  main: null,
+  checkpoint: null,
+  feature: null,
+};
+
+for (let index = 0; index < args.length; index++) {
+  const arg = args[index];
+  if (arg === '--expect-main') {
+    expectations.main = args[++index] ?? null;
+    continue;
+  }
+  if (arg === '--expect-checkpoint') {
+    expectations.checkpoint = args[++index] ?? null;
+    continue;
+  }
+  if (arg === '--expect-feature') {
+    expectations.feature = args[++index] ?? null;
+    continue;
+  }
+  positional.push(arg);
+}
+
+const [mainRootArg, checkpointRootArg, featureRootArg] = positional;
+
+if (!mainRootArg || !checkpointRootArg || !featureRootArg) {
+  console.error(
+    'Usage: node scripts/verify-core-parser-baselines.mjs <mainRoot> <checkpointRoot> <featureRoot> [--expect-main <sha>] [--expect-checkpoint <sha>] [--expect-feature <sha>]'
+  );
+  process.exit(1);
+}
+
+const repoRoots = {
+  main: path.resolve(mainRootArg),
+  checkpoint: path.resolve(checkpointRootArg),
+  feature: path.resolve(featureRootArg),
+};
+
+const worktrees = await getWorktreeList(repoRoots.feature);
+const repos = {};
+const issues = [];
+
+for (const [label, repoRoot] of Object.entries(repoRoots)) {
+  const git = await getGitMetadata(repoRoot);
+  const rawStatus = await getGitStatusSummary(repoRoot);
+  const status = {
+    dirty: false,
+    entries: rawStatus.entries.filter((entry) => !isIgnoredStatusEntry(entry)),
+  };
+  status.dirty = status.entries.length > 0;
+  const entrypoint = resolveBuiltDistEntrypoint(repoRoot);
+  const expectedHead = expectations[label];
+  const headMatchesExpected = expectedHead ? matchesExpectedHead(git.head, expectedHead) : null;
+
+  repos[label] = {
+    repoRoot,
+    git,
+    status,
+    entrypoint,
+    expectedHead,
+    headMatchesExpected,
+  };
+
+  if (expectedHead && !headMatchesExpected) {
+    issues.push(`${label} HEAD changed: expected ${expectedHead}, found ${git.head}`);
+  }
+}
+
+if (repos.main.status.dirty) {
+  issues.push('main worktree is dirty');
+}
+if (repos.checkpoint.status.dirty) {
+  issues.push('checkpoint worktree is dirty');
+}
+
+const summary = {
+  timestamp: new Date().toISOString(),
+  repoRoots,
+  worktrees,
+  repos,
+  issues,
+  ok: issues.length === 0,
+};
+
+console.log(JSON.stringify(summary, null, 2));
+
+if (issues.length > 0) {
+  process.exit(1);
+}
+
+function matchesExpectedHead(actualHead, expectedHead) {
+  return actualHead === expectedHead || actualHead.startsWith(expectedHead);
+}
+
+function isIgnoredStatusEntry(entry) {
+  return entry.endsWith('.omx/') || entry.includes(' .omx/');
+}


### PR DESCRIPTION
## Summary
- fix DTD/internal-subset chunk-boundary handling so mixed-content async parsing completes reliably
- recover cursor hot-path performance with scalar token state and deferred attribute parsing
- restore sync public wrapper performance with a direct parser path and sequential benchmark discipline
- align benchmark/profiling tooling around fixed main/checkpoint/feature worktrees and built-dist-only measurements
- fix package type mismatches so package-wide TypeScript checking passes again

## Perf Results
- Cursor gate: PASS
  - sync-cursor-consume: 55.31ms -> 31.03ms, +43.89%
  - sync-cursor-attr-unused: 52.14ms -> 31.81ms, +38.99%
  - async-cursor-midsize-4kb ratio: 0.82x vs checkpoint
  - async-cursor-midsize-64kb ratio: 0.87x vs checkpoint
- Wrapper gate: PASS
  - sync-parser-books regression: +2.13% vs main baseline
  - sync-parser-complex improvement: +6.05% vs main baseline
  - async-parser-midsize-4kb: feature completes, checksum stable
  - async-parser-midsize-64kb: feature completes, checksum stable
  - async-parser-mixed-256b: feature completes, checksum stable
- Stress suite: signal-only, feature async-parser-single-chunk completed with stable checksum

## Validation
- `pnpm build`
- `pnpm test`
- `bunx tsc --noEmit -p packages/stax-xml/tsconfig.json`
- `node ./scripts/evaluate-core-parser-gates.mjs cursor /tmp/stax-compare/checkpoint/benchmarks/cursor.json /tmp/stax-compare/feature/benchmarks/cursor.json`
- `node ./scripts/evaluate-core-parser-gates.mjs wrapper /tmp/stax-compare/main/benchmarks/wrapper.json /tmp/stax-compare/feature/benchmarks/wrapper.json`
- `node ./scripts/evaluate-core-parser-gates.mjs stress /tmp/stax-compare/main/benchmarks/wrapper.json /tmp/stax-compare/feature/benchmarks/stress.json`
- `node ./scripts/verify-core-parser-baselines.mjs /josh/programs/stax-xml /josh/programs/stax-xml-core-parser-checkpoint /josh/programs/stax-xml-core-parser-refactor --expect-main 7d6c713 --expect-checkpoint 97dbf5b --expect-feature 97dbf5b`
