### PR TITLE
docs workflow node version bump

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20.19.0'
+          node-version: '24.15.0'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6


### PR DESCRIPTION
unlike project build, docs doesnt need to pin prior node version to version compatibility