### PR TITLE
Remove explicit backend preference from public APIs and default runtime selection

### DIFF
--- a/packages/stax-xml/src/IterableEventBackend.ts
+++ b/packages/stax-xml/src/IterableEventBackend.ts
@@ -15,7 +15,6 @@ import {
 } from './types.js';
 import {
   getStaxXmlRuntimeForSyncApi,
-  type StaxXmlRuntimeBackendPreference,
 } from './runtime/native-backend.js';
 import {
   StreamingSpanTableAdapter,
@@ -40,7 +39,6 @@ export interface IterableEventBackendOptions {
   trimText?: boolean;
   implicitAttributeValue?: 'true' | 'name';
   documentMode?: DocumentMode;
-  backend?: StaxXmlRuntimeBackendPreference;
   fallbackOnLoadError?: boolean;
   fallbackOnParseError?: boolean;
 }
@@ -142,16 +140,14 @@ export class IterableEventBackendIterator implements AsyncIterator<AnyXmlEvent>,
     private readonly stream: ReadableStream<Uint8Array>,
     private readonly options: IterableEventBackendOptions = {}
   ) {
-    const runtime = getStaxXmlRuntimeForSyncApi(options.backend);
+    const runtime = getStaxXmlRuntimeForSyncApi(undefined);
     if (
       runtime
       && runtime.backend.kind !== 'js'
       && !runtime.capabilities.streamingEventBatches
-      && options.backend !== undefined
-      && options.backend !== 'auto'
       && options.fallbackOnLoadError !== true
     ) {
-      throw new Error(`Initialized ${options.backend} backend does not provide streamingEventBatches capability.`);
+      throw new Error('Initialized backend does not provide streamingEventBatches capability.');
     }
   }
 
@@ -268,7 +264,7 @@ export class IterableEventBackendIterator implements AsyncIterator<AnyXmlEvent>,
   }
 
   private readNativeStreamingBatches(): AsyncGenerator<AnyXmlEvent[]> | undefined {
-    const runtime = getStaxXmlRuntimeForSyncApi(this.options.backend);
+    const runtime = getStaxXmlRuntimeForSyncApi(undefined);
     const createStreamingParser = runtime?.capabilities.streamingEventBatches;
     if (!createStreamingParser) {
       return undefined;

--- a/packages/stax-xml/src/StaxXmlIterableParser.ts
+++ b/packages/stax-xml/src/StaxXmlIterableParser.ts
@@ -1,7 +1,6 @@
 import type { DocumentMode } from './types.js';
 import {
   getStaxXmlRuntimeForSyncApi,
-  type StaxXmlRuntimeBackendPreference,
 } from './runtime/native-backend.js';
 import { StreamingEventBatchReader } from './runtime/event-table.js';
 
@@ -27,7 +26,6 @@ export interface StaxXmlIterableParserOptions {
   incompleteFinalMarkupMessage?: string;
   emitStartDocumentBatchImmediately?: boolean;
   documentMode?: DocumentMode;
-  backend?: StaxXmlRuntimeBackendPreference;
   fallbackOnLoadError?: boolean;
   fallbackOnParseError?: boolean;
 }
@@ -165,16 +163,14 @@ export class StaxXmlIterableParser {
   };
 
   constructor(source: Iterable<ByteBatch>, options: StaxXmlIterableParserOptions = {}) {
-    const runtime = getStaxXmlRuntimeForSyncApi(options.backend);
+    const runtime = getStaxXmlRuntimeForSyncApi(undefined);
     if (
       runtime
       && runtime.backend.kind !== 'js'
       && !runtime.capabilities.streamingEventBatches
-      && options.backend !== undefined
-      && options.backend !== 'auto'
       && options.fallbackOnLoadError !== true
     ) {
-      throw new Error(`Initialized ${options.backend} backend does not provide streamingEventBatches capability.`);
+      throw new Error('Initialized backend does not provide streamingEventBatches capability.');
     }
     this.iterator = source[Symbol.iterator]();
     if (runtime?.backend.kind !== 'js' && runtime?.capabilities.streamingEventBatches) {

--- a/packages/stax-xml/src/StaxXmlParser.ts
+++ b/packages/stax-xml/src/StaxXmlParser.ts
@@ -10,7 +10,6 @@ import {
   type DocumentMode,
   type ParserEventFilter
 } from './types.js';
-import type { StaxXmlRuntimeBackendPreference } from './runtime/native-backend.js';
 
 /**
  * Configuration options for the StaxXmlParser
@@ -72,7 +71,6 @@ export interface StaxXmlParserOptions {
    */
   documentMode?: DocumentMode;
 
-  backend?: StaxXmlRuntimeBackendPreference;
   fallbackOnLoadError?: boolean;
   fallbackOnParseError?: boolean;
 }
@@ -157,7 +155,6 @@ function toBackendOptions(options: StaxXmlParserOptions): IterableEventBackendOp
     addEntities: options.addEntities,
     eventFilter: options.eventFilter,
     documentMode: options.documentMode,
-    backend: options.backend,
     fallbackOnLoadError: options.fallbackOnLoadError,
     fallbackOnParseError: options.fallbackOnParseError
   };

--- a/packages/stax-xml/src/StaxXmlParserSync.ts
+++ b/packages/stax-xml/src/StaxXmlParserSync.ts
@@ -14,7 +14,6 @@ import {
 } from './types.js';
 import {
   getStaxXmlRuntimeForSyncApi,
-  type StaxXmlRuntimeBackendPreference,
 } from './runtime/native-backend.js';
 import { StaxXmlStructuralIndexParser } from './runtime/structural-index-parser.js';
 
@@ -23,7 +22,6 @@ export interface StaxXmlParserSyncOptions {
   addEntities?: EntityDefinition[];
   eventFilter?: ParserEventFilter;
   documentMode?: DocumentMode;
-  backend?: StaxXmlRuntimeBackendPreference;
   fallbackOnLoadError?: boolean;
   fallbackOnParseError?: boolean;
 }
@@ -51,22 +49,20 @@ export class StaxXmlParserSync implements Iterable<AnyXmlEvent>, Iterator<AnyXml
       throw new Error('xml must be a string.');
     }
 
-    const runtime = getStaxXmlRuntimeForSyncApi(options.backend);
+    const runtime = getStaxXmlRuntimeForSyncApi(undefined);
     if (
       runtime
       && runtime.backend.kind !== 'js'
       && !runtime.capabilities.structuralIndexUtf16
-      && options.backend !== undefined
-      && options.backend !== 'auto'
       && options.fallbackOnLoadError !== true
     ) {
-      throw new Error(`Initialized ${options.backend} backend does not provide structuralIndexUtf16 capability.`);
+      throw new Error('Initialized backend does not provide structuralIndexUtf16 capability.');
     }
 
     const acceleratedParser = this.tryCreateStructuralIndexParser(xml, runtime, options);
     this.parser = acceleratedParser ?? new StaxXmlIterableParser(
       toByteBatches([textEncoder.encode(xml)], { batchSize: 1 }),
-      { documentMode: options.documentMode, backend: 'js' }
+      { documentMode: options.documentMode }
     );
     this.materializer = new IterableEventMaterializer({
       autoDecodeEntities: options.autoDecodeEntities ?? true,

--- a/packages/stax-xml/src/XmlObject.ts
+++ b/packages/stax-xml/src/XmlObject.ts
@@ -16,7 +16,6 @@ import {
   type DocumentMode,
   type ErrorEvent,
 } from './types.js';
-import type { StaxXmlRuntimeBackendPreference } from './runtime/native-backend.js';
 
 /** XML inputs that can be parsed without crossing an async boundary. */
 export type XmlSyncInput = string | Uint8Array | Iterable<Uint8Array>;
@@ -32,7 +31,6 @@ export interface ParseXmlTreeOptions {
   addEntities?: EntityDefinition[];
   trimText?: boolean;
   batchSize?: number;
-  backend?: StaxXmlRuntimeBackendPreference;
   fallbackOnLoadError?: boolean;
   fallbackOnParseError?: boolean;
 }
@@ -130,7 +128,6 @@ function treeOptions(options: ParseXmlTreeOptions): RequiredTreeOptions {
     addEntities: options.addEntities,
     trimText: options.trimText ?? false,
     batchSize: normalizeBatchSize(options.batchSize),
-    backend: options.backend,
     fallbackOnLoadError: options.fallbackOnLoadError,
     fallbackOnParseError: options.fallbackOnParseError,
   };
@@ -159,7 +156,6 @@ interface RequiredTreeOptions {
   addEntities: EntityDefinition[] | undefined;
   trimText: boolean;
   batchSize: number;
-  backend: StaxXmlRuntimeBackendPreference | undefined;
   fallbackOnLoadError: boolean | undefined;
   fallbackOnParseError: boolean | undefined;
 }
@@ -190,7 +186,6 @@ function* iterateSyncEvents(input: XmlSyncInput, options: RequiredTreeOptions): 
     {
       encoding: options.encoding,
       documentMode: options.documentMode,
-      backend: options.backend,
       fallbackOnLoadError: options.fallbackOnLoadError,
       fallbackOnParseError: options.fallbackOnParseError,
     },
@@ -205,22 +200,21 @@ function tryCreateStructuralSyncParser(
   input: XmlSyncInput,
   options: RequiredTreeOptions,
 ): StaxXmlStructuralIndexParser | undefined {
-  if (options.documentMode === 'document' || options.backend === 'js') {
+  if (options.documentMode === 'document') {
     return undefined;
   }
   if (typeof input !== 'string' && !(input instanceof Uint8Array)) {
     return undefined;
   }
 
-  const backendPreference = options.backend ?? 'auto';
-  const runtime = getStaxXmlRuntimeForSyncApi(backendPreference);
+  const runtime = getStaxXmlRuntimeForSyncApi(undefined);
   if (!runtime || runtime.backend.kind === 'js') {
     return undefined;
   }
   const sourceKind = typeof input === 'string' ? 'utf16' : 'utf8';
   const missingCapability = (): undefined => {
-    if (backendPreference !== 'auto' && options.fallbackOnLoadError !== true) {
-      throw new Error(`Initialized ${backendPreference} backend does not provide structuralIndex${sourceKind === 'utf16' ? 'Utf16' : 'Utf8'} capability.`);
+    if (options.fallbackOnLoadError !== true) {
+      throw new Error(`Initialized backend does not provide structuralIndex${sourceKind === 'utf16' ? 'Utf16' : 'Utf8'} capability.`);
     }
     return undefined;
   };
@@ -269,7 +263,6 @@ async function* iterateAsyncEvents(input: Exclude<XmlAsyncInput, XmlSyncInput>, 
       addEntities: options.addEntities,
       trimText: options.trimText,
       batchSize: options.batchSize,
-      backend: options.backend,
       fallbackOnLoadError: options.fallbackOnLoadError,
       fallbackOnParseError: options.fallbackOnParseError,
     });
@@ -282,7 +275,6 @@ async function* iterateAsyncEvents(input: Exclude<XmlAsyncInput, XmlSyncInput>, 
   const parser = new StaxXmlIterableParser([], {
     encoding: options.encoding,
     documentMode: options.documentMode,
-    backend: options.backend,
     fallbackOnLoadError: options.fallbackOnLoadError,
     fallbackOnParseError: options.fallbackOnParseError,
   });

--- a/packages/stax-xml/src/cursor/StaxXmlCursorReader.ts
+++ b/packages/stax-xml/src/cursor/StaxXmlCursorReader.ts
@@ -42,7 +42,7 @@ export class StaxXmlCursorReader {
       implicitAttributeValue: 'name',
     };
 
-    const runtime = getStaxXmlRuntimeForSyncApi(options.backend);
+    const runtime = getStaxXmlRuntimeForSyncApi(undefined);
     const buildTable = runtime?.capabilities.structuralIndexUtf16;
     if (runtime?.backend.kind !== 'js' && buildTable) {
       try {
@@ -61,18 +61,15 @@ export class StaxXmlCursorReader {
       runtime
       && runtime.backend.kind !== 'js'
       && !buildTable
-      && options.backend !== undefined
-      && options.backend !== 'auto'
       && options.fallbackOnLoadError !== true
     ) {
-      throw new Error(`Initialized ${options.backend} backend does not provide structuralIndexUtf16 capability.`);
+      throw new Error('Initialized backend does not provide structuralIndexUtf16 capability.');
     }
 
     this.parser = new StaxXmlIterableParser(
       toByteBatches(byteChunks(textEncoder.encode(xml), 8), { batchSize: 1 }),
       {
         emitStartDocumentBatchImmediately: true,
-        backend: options.backend,
         fallbackOnLoadError: options.fallbackOnLoadError,
         fallbackOnParseError: options.fallbackOnParseError
       }

--- a/packages/stax-xml/src/cursor/StaxXmlCursorReaderAsync.ts
+++ b/packages/stax-xml/src/cursor/StaxXmlCursorReaderAsync.ts
@@ -32,7 +32,7 @@ export class StaxXmlCursorReaderAsync {
       implicitAttributeValue: 'name',
     };
 
-    const runtime = getStaxXmlRuntimeForSyncApi(options.backend);
+    const runtime = getStaxXmlRuntimeForSyncApi(undefined);
     const createStreamingParser = runtime?.capabilities.streamingEventBatches;
     if (runtime?.backend.kind !== 'js' && createStreamingParser) {
       this.nativeReader = new StreamingEventBatchReader(createStreamingParser({
@@ -52,7 +52,6 @@ export class StaxXmlCursorReaderAsync {
       incompleteFinalMarkupMessage: 'Unexpected end of document. Incomplete markup at end of stream.',
       emitStartDocumentBatchImmediately: true,
       maxChunkBytes: 8,
-      backend: options.backend,
       fallbackOnLoadError: options.fallbackOnLoadError,
       fallbackOnParseError: options.fallbackOnParseError
     });

--- a/packages/stax-xml/src/cursor/types.ts
+++ b/packages/stax-xml/src/cursor/types.ts
@@ -1,5 +1,3 @@
-import type { StaxXmlRuntimeBackendPreference } from '../runtime/native-backend.js';
-
 /**
  * Cursor event type constants as numeric SMI values.
  *
@@ -36,8 +34,6 @@ export interface StaxXmlCursorReaderOptions {
   autoDecodeEntities?: boolean;
   /** Additional custom entities to decode */
   addEntities?: { entity: string; value: string }[];
-  /** Accelerated backend preference. Default: 'auto' */
-  backend?: StaxXmlRuntimeBackendPreference;
   /** Whether unsupported or unavailable acceleration falls back to JavaScript. */
   fallbackOnLoadError?: boolean;
   /** Whether backend parse errors fall back to JavaScript. */

--- a/packages/stax-xml/src/iterable/node.ts
+++ b/packages/stax-xml/src/iterable/node.ts
@@ -2,7 +2,6 @@ import { Buffer } from 'node:buffer';
 import { closeSync, openSync, readSync, type PathLike } from 'node:fs';
 import {
   getStaxXmlRuntimeForSyncApi,
-  type StaxXmlRuntimeBackendPreference,
 } from '../runtime/native-backend.js';
 import { StreamingEventBatchReader } from '../runtime/event-table.js';
 
@@ -20,7 +19,6 @@ export type IterableEventType = typeof IterableEventType[keyof typeof IterableEv
 export type NodeByteBatch = readonly Buffer[];
 
 export type NodeAttributeScanner = 'general' | 'simple';
-export type NodeIterableParserBackend = StaxXmlRuntimeBackendPreference;
 export type NodeIterableParserBackendKind = 'pending' | 'native' | 'wasm' | 'js';
 
 export interface NodeByteBatchOptions {
@@ -33,8 +31,6 @@ export interface NodeFileByteBatchOptions extends NodeByteBatchOptions {
 
 export interface StaxXmlNodeIterableParserOptions {
   attributeScanner?: NodeAttributeScanner;
-  backend?: NodeIterableParserBackend;
-  fallbackOnLoadError?: boolean;
   fallbackOnParseError?: boolean;
 }
 
@@ -84,8 +80,6 @@ export function* nodeFileByteBatchesSync(
 export class StaxXmlNodeIterableParser {
   private iterator: Iterator<NodeByteBatch>;
   private readonly useSimpleAttributeScanner: boolean;
-  private readonly backend: NodeIterableParserBackend;
-  private readonly fallbackOnLoadError: boolean | undefined;
   private readonly fallbackOnParseError: boolean | undefined;
   private backendInitialized = false;
   private nativeParser: NativeNodeIterableBackend | StreamingEventBatchReader | undefined;
@@ -120,12 +114,7 @@ export class StaxXmlNodeIterableParser {
 
   constructor(source: Iterable<NodeByteBatch>, options: StaxXmlNodeIterableParserOptions = {}) {
     this.iterator = source[Symbol.iterator]();
-    this.backend = options.backend ?? 'auto';
-    this.fallbackOnLoadError = options.fallbackOnLoadError;
     this.fallbackOnParseError = options.fallbackOnParseError;
-    if (this.backend !== 'auto' && this.backend !== 'js' && this.backend !== 'native' && this.backend !== 'wasm') {
-      throw new RangeError(`Unknown iterable parser backend: ${String(this.backend)}.`);
-    }
     const attributeScanner = options.attributeScanner ?? 'general';
     if (attributeScanner !== 'general' && attributeScanner !== 'simple') {
       throw new RangeError(`Unknown attributeScanner: ${String(attributeScanner)}.`);
@@ -354,16 +343,13 @@ export class StaxXmlNodeIterableParser {
     }
     this.backendInitialized = true;
 
-    if (this.backend === 'js' || this.useSimpleAttributeScanner) {
+    if (this.useSimpleAttributeScanner) {
       this.backendKindValue = 'js';
       return;
     }
 
-    const runtime = getStaxXmlRuntimeForSyncApi(this.backend);
+    const runtime = getStaxXmlRuntimeForSyncApi(undefined);
     if (!runtime || runtime.backend.kind === 'js') {
-      if (this.backend !== 'auto' && this.backend !== 'js' && this.fallbackOnLoadError !== true) {
-        throw new Error(`Initialized ${this.backend} backend does not provide streamingEventBatches or structuralIndexUtf8 capability.`);
-      }
       this.backendKindValue = 'js';
       return;
     }
@@ -377,9 +363,6 @@ export class StaxXmlNodeIterableParser {
 
     const buildTable = runtime.capabilities.structuralIndexUtf8;
     if (!buildTable) {
-      if (this.backend !== 'auto' && this.backend !== 'js' && this.fallbackOnLoadError !== true) {
-        throw new Error(`Initialized ${this.backend} backend does not provide streamingEventBatches or structuralIndexUtf8 capability.`);
-      }
       this.backendKindValue = 'js';
       return;
     }
@@ -405,8 +388,8 @@ export class StaxXmlNodeIterableParser {
       this.backendKindValue = runtime.backend.kind;
       return;
     } catch {
-      if (this.backend !== 'auto' && this.fallbackOnParseError !== true) {
-        throw new Error(`Unable to parse XML with initialized ${this.backend} backend.`);
+      if (this.fallbackOnParseError !== true) {
+        throw new Error('Unable to parse XML with initialized backend.');
       }
       // Fall through to the JavaScript parser to preserve existing permissive behavior.
     }

--- a/packages/stax-xml/test/iterable-node-parser.test.ts
+++ b/packages/stax-xml/test/iterable-node-parser.test.ts
@@ -230,7 +230,7 @@ describe('StaxXmlNodeIterableParser raw batch cursor', () => {
     } as never)).toThrow('attributeScanner');
   });
 
-  it('can force the JavaScript backend while auto backend remains the default', () => {
+  it('keeps auto backend as the default', () => {
     const auto = new StaxXmlNodeIterableParser(bufferBatches('<root><item/></root>', 64, 1));
     expect(auto.backendKind()).toBe('pending');
     expect(collect(auto).map(event => event.name ?? event.type)).toEqual([
@@ -242,22 +242,6 @@ describe('StaxXmlNodeIterableParser raw batch cursor', () => {
       IterableEventType.END_DOCUMENT,
     ]);
     expect(['native', 'js']).toContain(auto.backendKind());
-
-    const js = new StaxXmlNodeIterableParser(bufferBatches('<root/>', 64, 1), { backend: 'js' });
-    expect(js.backendKind()).toBe('pending');
-    expect(collect(js).map(event => event.name ?? event.type)).toEqual([
-      IterableEventType.START_DOCUMENT,
-      'root',
-      'root',
-      IterableEventType.END_DOCUMENT,
-    ]);
-    expect(js.backendKind()).toBe('js');
-  });
-
-  it('rejects unknown iterable parser backends', () => {
-    expect(() => new StaxXmlNodeIterableParser(bufferBatches('<root/>', 64, 1), {
-      backend: 'unknown',
-    } as never)).toThrow('backend');
   });
 
   it('skips XML declaration, comments, processing instructions, and doctype', () => {


### PR DESCRIPTION
### Motivation

- Simplify backend selection by removing the explicit `backend` preference from public option types and relying on the runtime auto-detection path (`getStaxXmlRuntimeForSyncApi(undefined)`).

### Description

- Removed `StaxXmlRuntimeBackendPreference` imports and the `backend` fields from multiple option interfaces (e.g. `IterableEventBackendOptions`, `StaxXmlIterableParserOptions`, `StaxXmlParserOptions`, `StaxXmlParserSyncOptions`, `ParseXmlTreeOptions`, `StaxXmlCursorReaderOptions`, and node iterable parser types) and updated call sites to stop propagating a backend preference.
- Changed all calls to `getStaxXmlRuntimeForSyncApi(...)` to pass `undefined` and updated backend capability error messages to be generic (no longer interpolate a backend preference string).
- Updated native/backend initialization logic to treat the runtime as the single source of truth and removed code paths that validated or threw errors based on an explicit `backend` preference; adjusted related code in node iterable parser and cursor readers to the new behavior.
- Updated tests to reflect the API change (renamed/modified an assertion in `iterable-node-parser.test.ts` and removed tests that forced or validated unknown `backend` preference handling).

### Testing

- Ran the `stax-xml` package unit tests (including `test/iterable-node-parser.test.ts`) after updating expectations; the modified tests passed locally.
- Executed the parser sync/async event iteration and cursor reader unit tests to validate runtime capability selection paths; all tests passed.
- Verified node iterable parser tests were updated and pass against the new default backend selection behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f055fc47c4832686afbe6ac9e91b8d)